### PR TITLE
chore: add rpc_endpoints + etherscan config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,3 +12,17 @@ cbor_metadata = false
 
 [fuzz]
 runs = 2048
+
+[rpc_endpoints]
+arbitrum = "${CI_DEPLOY_ARBITRUM_RPC_URL}"
+base = "${CI_DEPLOY_BASE_RPC_URL}"
+base_sepolia = "${CI_DEPLOY_BASE_SEPOLIA_RPC_URL}"
+flare = "${CI_DEPLOY_FLARE_RPC_URL}"
+polygon = "${CI_DEPLOY_POLYGON_RPC_URL}"
+
+[etherscan]
+arbitrum = { key = "${CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY}" }
+base = { key = "${CI_DEPLOY_BASE_ETHERSCAN_API_KEY}" }
+base_sepolia = { key = "${CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY}" }
+flare = { key = "${CI_DEPLOY_FLARE_ETHERSCAN_API_KEY}" }
+polygon = { key = "${CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY}" }


### PR DESCRIPTION
The deploy run on `manual-sol-artifacts.yaml` failed with `vm.createSelectFork: invalid rpc url: arbitrum` because rain.extrospection's `foundry.toml` had no `[rpc_endpoints]` section. `LibRainDeploy.deployToNetworks` calls `vm.createSelectFork(networkName)` for each Rain-supported network — without the foundry config mapping each name to a URL placeholder, none resolve.

Add `[rpc_endpoints]` and `[etherscan]` sections matching the `CI_DEPLOY_*_RPC_URL` / `CI_DEPLOY_*_ETHERSCAN_API_KEY` env vars set by the workflow. Same shape st0x.deploy uses.
