### PR TITLE
chore: arm key-backup workflow after dry-run

### DIFF
--- a/.github/workflows/key-backup.yaml
+++ b/.github/workflows/key-backup.yaml
@@ -23,10 +23,7 @@ jobs:
       # The deploy job at run 25595175381 surfaced this address as the
       # signer of the broadcast attempt. Re-deriving and matching here
       # catches a rotated/wrong key before exfiltrating its ciphertext.
-      # MUTATION-TEST: deliberately wrong address so the guard fails. Revert
-      # back to 0x3AD9c7CCd0bcCf569638C5c485b29b35cFB6D2A2 once the dry-run
-      # has demonstrated the guard fires.
-      EXPECTED_ADDRESS: '0x000000000000000000000000000000000000dEaD'
+      EXPECTED_ADDRESS: '0x3AD9c7CCd0bcCf569638C5c485b29b35cFB6D2A2'
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
@@ -47,18 +44,15 @@ jobs:
             exit 1
           fi
           echo "Verified: PRIVATE_KEY derives to $actual"
-      # Exfiltration steps disabled for the initial dry-run. Once the
-      # address-derivation guard above has confirmed the right key,
-      # uncomment and re-dispatch.
-      # - name: Encrypt secret
-      #   env:
-      #     PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-      #   run: |
-      #     printf '%s' "$PRIVATE_KEY" | nix develop -c age --recipient "$AGE_RECIPIENT" --output backup.age
-      #     ls -la backup.age
-      # - name: Upload encrypted artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: encrypted-key
-      #     path: backup.age
-      #     retention-days: 1
+      - name: Encrypt secret
+        env:
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: |
+          printf '%s' "$PRIVATE_KEY" | nix develop -c age --recipient "$AGE_RECIPIENT" --output backup.age
+          ls -la backup.age
+      - name: Upload encrypted artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: encrypted-key
+          path: backup.age
+          retention-days: 1


### PR DESCRIPTION
Follow-up to #30. Dry-run of run [25598320605](https://github.com/rainlanguage/rain.extrospection/actions/runs/25598320605) confirmed the address-derivation guard fires correctly when `EXPECTED_ADDRESS` doesn't match what `PRIVATE_KEY` derives to:

```
##[error]PRIVATE_KEY derives to 0x3AD9c7CCd0bcCf569638C5c485b29b35cFB6D2A2 but expected 0x000000000000000000000000000000000000dEaD — refusing to back up the wrong key
```

This PR:
1. Restores `EXPECTED_ADDRESS` to the real signer `0x3AD9c7CCd0bcCf569638C5c485b29b35cFB6D2A2`.
2. Uncomments the encrypt + upload steps.

After merge:
1. Dispatch the `Key backup` workflow on main.
2. Download the `encrypted-key` artifact.
3. Decrypt locally: `age --decrypt --identity ~/.config/age/rain-extrospection-backup.txt backup.age`.
4. Open a follow-up PR removing the workflow file.
