### PR TITLE
Tighten Extrospect equivalence tests to compare revert payloads

### DIFF
--- a/test/concrete/ExtrospectEquivalence.sol
+++ b/test/concrete/ExtrospectEquivalence.sol
@@ -14,4 +14,31 @@ abstract contract ExtrospectEquivalence is Test {
     function setUp() external {
         extrospect = new Extrospect();
     }
+
+    /// Invokes `selector` with `args` against `target` as a raw low-level call,
+    /// returning the success flag and the raw returndata (the ABI-encoded return
+    /// values on success, or the ABI-encoded revert payload on failure).
+    /// Capturing the returndata in both branches lets the equivalence tests
+    /// compare the concrete and library outputs byte-for-byte regardless of
+    /// whether the call succeeded or reverted — a regression that remapped one
+    /// revert selector/payload to another is caught, not just "both reverted".
+    function rawCall(address target, bytes4 selector, bytes memory args)
+        internal
+        returns (bool success, bytes memory returndata)
+    {
+        (success, returndata) = target.call(abi.encodePacked(selector, args));
+    }
+
+    /// Asserts that the concrete `Extrospect` instance and the library wrapper
+    /// (both addressed via `address(this)` self-calls where the test contract
+    /// re-exposes the library) produce byte-identical outcomes for `args`: the
+    /// same success flag and the same raw returndata. On the success path this
+    /// compares the encoded return values; on the revert path it compares the
+    /// revert selector and every encoded argument byte-for-byte.
+    function assertEquivalence(bytes4 extSelector, bytes4 libSelector, bytes memory args) internal {
+        (bool extSuccess, bytes memory extReturndata) = rawCall(address(extrospect), extSelector, args);
+        (bool libSuccess, bytes memory libReturndata) = rawCall(address(this), libSelector, args);
+        assertEq(extSuccess, libSuccess, "success flag mismatch");
+        assertEq(extReturndata, libReturndata, "returndata mismatch");
+    }
 }

--- a/test/src/concrete/Extrospect.checkNotMetamorphic.t.sol
+++ b/test/src/concrete/Extrospect.checkNotMetamorphic.t.sol
@@ -6,21 +6,43 @@ import {ExtrospectEquivalence} from "test/concrete/ExtrospectEquivalence.sol";
 import {LibExtrospectMetamorphic} from "src/lib/LibExtrospectMetamorphic.sol";
 
 contract ExtrospectCheckNotMetamorphicTest is ExtrospectEquivalence {
+    /// External re-exposure of the library function so it can be reached via a
+    /// raw self-call and its returndata captured alongside the concrete's.
     function libCheckNotMetamorphicExternal(bytes memory bytecode) external pure {
         LibExtrospectMetamorphic.checkNotMetamorphic(bytecode);
     }
 
-    function testCheckNotMetamorphicEquivalencePass() external view {
-        bytes memory clean = hex"60016002F3";
-        extrospect.checkNotMetamorphic(clean);
-        LibExtrospectMetamorphic.checkNotMetamorphic(clean);
+    function assertCheckNotMetamorphicEquivalence(bytes memory bytecode) internal {
+        assertEquivalence(
+            extrospect.checkNotMetamorphic.selector, this.libCheckNotMetamorphicExternal.selector, abi.encode(bytecode)
+        );
     }
 
+    /// Concrete and library agree on the success (no-revert) path: both return
+    /// empty returndata.
+    function testCheckNotMetamorphicEquivalencePass() external {
+        bytes memory clean = hex"60016002F3";
+        assertCheckNotMetamorphicEquivalence(clean);
+    }
+
+    /// Concrete and library revert with the byte-identical `Metamorphic`
+    /// payload (selector + the exact reachable-opcode bitmap) for risky
+    /// bytecode.
     function testCheckNotMetamorphicEquivalenceRevert() external {
         bytes memory withDelegatecall = hex"60006000600060006000F4";
-        vm.expectRevert();
-        extrospect.checkNotMetamorphic(withDelegatecall);
-        vm.expectRevert();
-        this.libCheckNotMetamorphicExternal(withDelegatecall);
+        assertCheckNotMetamorphicEquivalence(withDelegatecall);
+    }
+
+    /// Concrete and library revert with the byte-identical
+    /// `EOFBytecodeNotSupported` payload for EOF-prefixed bytecode.
+    function testCheckNotMetamorphicEquivalenceEOF() external {
+        bytes memory eof = hex"EF0000";
+        assertCheckNotMetamorphicEquivalence(eof);
+    }
+
+    /// Fuzz the success and both revert paths together: every input yields the
+    /// same success flag and byte-identical returndata on both sides.
+    function testCheckNotMetamorphicEquivalenceFuzz(bytes memory bytecode) external {
+        assertCheckNotMetamorphicEquivalence(bytecode);
     }
 }

--- a/test/src/concrete/Extrospect.scanEVMOpcodesPresentInBytecode.t.sol
+++ b/test/src/concrete/Extrospect.scanEVMOpcodesPresentInBytecode.t.sol
@@ -6,29 +6,34 @@ import {ExtrospectEquivalence} from "test/concrete/ExtrospectEquivalence.sol";
 import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
 
 contract ExtrospectScanEVMOpcodesPresentInBytecodeTest is ExtrospectEquivalence {
-    function testScanEVMOpcodesPresentInBytecodeEquivalenceFuzz(bytes memory bytecode) external {
-        try this._extScan(bytecode) returns (uint256 ext) {
-            uint256 lib = LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(bytecode);
-            assertEq(ext, lib);
-        } catch {
-            vm.expectRevert();
-            this._libScan(bytecode);
-        }
-    }
-
-    function _extScan(bytes memory bytecode) external view returns (uint256) {
-        return extrospect.scanEVMOpcodesPresentInBytecode(bytecode);
-    }
-
+    /// External re-exposure of the library function so it can be reached via a
+    /// raw self-call and its returndata captured alongside the concrete's.
     function _libScan(bytes memory bytecode) external pure returns (uint256) {
         return LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(bytecode);
     }
 
-    function testScanEVMOpcodesPresentInBytecodeEquivalenceConcrete() external view {
-        bytes memory code = hex"60016002F3";
-        assertEq(
-            extrospect.scanEVMOpcodesPresentInBytecode(code),
-            LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(code)
+    function assertScanEquivalence(bytes memory bytecode) internal {
+        assertEquivalence(
+            extrospect.scanEVMOpcodesPresentInBytecode.selector, this._libScan.selector, abi.encode(bytecode)
         );
+    }
+
+    /// Concrete and library agree byte-for-byte on the success path: both
+    /// return the same encoded opcode bitmap, and on the EOF revert path both
+    /// emit the byte-identical `EOFBytecodeNotSupported` payload.
+    function testScanEVMOpcodesPresentInBytecodeEquivalenceFuzz(bytes memory bytecode) external {
+        assertScanEquivalence(bytecode);
+    }
+
+    /// Concrete and library return the byte-identical opcode bitmap for a
+    /// concrete success-path input.
+    function testScanEVMOpcodesPresentInBytecodeEquivalenceConcrete() external {
+        assertScanEquivalence(hex"60016002F3");
+    }
+
+    /// Concrete and library revert with the byte-identical
+    /// `EOFBytecodeNotSupported` payload for EOF-prefixed bytecode.
+    function testScanEVMOpcodesPresentInBytecodeEquivalenceEOF() external {
+        assertScanEquivalence(hex"EF0000");
     }
 }

--- a/test/src/concrete/Extrospect.scanEVMOpcodesReachableInBytecode.t.sol
+++ b/test/src/concrete/Extrospect.scanEVMOpcodesReachableInBytecode.t.sol
@@ -6,31 +6,35 @@ import {ExtrospectEquivalence} from "test/concrete/ExtrospectEquivalence.sol";
 import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
 
 contract ExtrospectScanEVMOpcodesReachableInBytecodeTest is ExtrospectEquivalence {
-    function testScanEVMOpcodesReachableInBytecodeEquivalenceFuzz(bytes memory bytecode) external {
-        // EOF prefix reverts both sides — skip via try/catch comparison.
-        try this._extScan(bytecode) returns (uint256 ext) {
-            uint256 lib = LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(bytecode);
-            assertEq(ext, lib);
-        } catch {
-            // Library should also revert.
-            vm.expectRevert();
-            this._libScan(bytecode);
-        }
-    }
-
-    function _extScan(bytes memory bytecode) external view returns (uint256) {
-        return extrospect.scanEVMOpcodesReachableInBytecode(bytecode);
-    }
-
+    /// External re-exposure of the library function so it can be reached via a
+    /// raw self-call and its returndata captured alongside the concrete's.
     function _libScan(bytes memory bytecode) external pure returns (uint256) {
         return LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(bytecode);
     }
 
-    function testScanEVMOpcodesReachableInBytecodeEquivalenceConcrete() external view {
-        bytes memory code = hex"60016002F3"; // PUSH1 0x01 PUSH1 0x02 RETURN
-        assertEq(
-            extrospect.scanEVMOpcodesReachableInBytecode(code),
-            LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(code)
+    function assertScanEquivalence(bytes memory bytecode) internal {
+        assertEquivalence(
+            extrospect.scanEVMOpcodesReachableInBytecode.selector, this._libScan.selector, abi.encode(bytecode)
         );
+    }
+
+    /// Concrete and library agree byte-for-byte on the success path: both
+    /// return the same encoded reachable-opcode bitmap, and on the EOF revert
+    /// path both emit the byte-identical `EOFBytecodeNotSupported` payload.
+    function testScanEVMOpcodesReachableInBytecodeEquivalenceFuzz(bytes memory bytecode) external {
+        assertScanEquivalence(bytecode);
+    }
+
+    /// Concrete and library return the byte-identical reachable-opcode bitmap
+    /// for a concrete success-path input.
+    function testScanEVMOpcodesReachableInBytecodeEquivalenceConcrete() external {
+        // PUSH1 0x01 PUSH1 0x02 RETURN
+        assertScanEquivalence(hex"60016002F3");
+    }
+
+    /// Concrete and library revert with the byte-identical
+    /// `EOFBytecodeNotSupported` payload for EOF-prefixed bytecode.
+    function testScanEVMOpcodesReachableInBytecodeEquivalenceEOF() external {
+        assertScanEquivalence(hex"EF0000");
     }
 }

--- a/test/src/concrete/Extrospect.scanMetamorphicRisk.t.sol
+++ b/test/src/concrete/Extrospect.scanMetamorphicRisk.t.sol
@@ -6,26 +6,32 @@ import {ExtrospectEquivalence} from "test/concrete/ExtrospectEquivalence.sol";
 import {LibExtrospectMetamorphic} from "src/lib/LibExtrospectMetamorphic.sol";
 
 contract ExtrospectScanMetamorphicRiskTest is ExtrospectEquivalence {
-    function testScanMetamorphicRiskEquivalenceFuzz(bytes memory bytecode) external {
-        try this._extScan(bytecode) returns (uint256 ext) {
-            uint256 lib = LibExtrospectMetamorphic.scanMetamorphicRisk(bytecode);
-            assertEq(ext, lib);
-        } catch {
-            vm.expectRevert();
-            this._libScan(bytecode);
-        }
-    }
-
-    function _extScan(bytes memory bytecode) external view returns (uint256) {
-        return extrospect.scanMetamorphicRisk(bytecode);
-    }
-
+    /// External re-exposure of the library function so it can be reached via a
+    /// raw self-call and its returndata captured alongside the concrete's.
     function _libScan(bytes memory bytecode) external pure returns (uint256) {
         return LibExtrospectMetamorphic.scanMetamorphicRisk(bytecode);
     }
 
-    function testScanMetamorphicRiskEquivalenceWithDelegatecall() external view {
-        bytes memory code = hex"60006000600060006000F4";
-        assertEq(extrospect.scanMetamorphicRisk(code), LibExtrospectMetamorphic.scanMetamorphicRisk(code));
+    function assertScanEquivalence(bytes memory bytecode) internal {
+        assertEquivalence(extrospect.scanMetamorphicRisk.selector, this._libScan.selector, abi.encode(bytecode));
+    }
+
+    /// Concrete and library agree byte-for-byte on the success path: both
+    /// return the same encoded metamorphic-risk bitmap, and on the EOF revert
+    /// path both emit the byte-identical `EOFBytecodeNotSupported` payload.
+    function testScanMetamorphicRiskEquivalenceFuzz(bytes memory bytecode) external {
+        assertScanEquivalence(bytecode);
+    }
+
+    /// Concrete and library return the byte-identical metamorphic-risk bitmap
+    /// for bytecode containing a reachable DELEGATECALL.
+    function testScanMetamorphicRiskEquivalenceWithDelegatecall() external {
+        assertScanEquivalence(hex"60006000600060006000F4");
+    }
+
+    /// Concrete and library revert with the byte-identical
+    /// `EOFBytecodeNotSupported` payload for EOF-prefixed bytecode.
+    function testScanMetamorphicRiskEquivalenceEOF() external {
+        assertScanEquivalence(hex"EF0000");
     }
 }


### PR DESCRIPTION
## What

The per-fn equivalence tests added in #26 used bare `vm.expectRevert()` (or a `try/catch` that only noted "the lib reverted too") on the revert-path branches. That catches "both reverted" but not "both reverted with the same selector + payload" — a regression in the concrete that mapped one error to another would still pass.

This strengthens the four named equivalence tests **in place** so they compare the concrete `Extrospect` and the library output **byte-for-byte** on every path:

- `Extrospect.checkNotMetamorphic.t.sol`
- `Extrospect.scanEVMOpcodesPresentInBytecode.t.sol`
- `Extrospect.scanEVMOpcodesReachableInBytecode.t.sol`
- `Extrospect.scanMetamorphicRisk.t.sol`

## How

A shared helper in `ExtrospectEquivalence` (`assertEquivalence`) routes both the concrete call and a library wrapper self-call through raw low-level calls that capture `(success, returndata)`, then asserts both the success flag and the **raw returndata** are equal regardless of which branch fired. On the success path this compares the encoded return value; on the revert path it compares the revert selector and every encoded argument (the `Metamorphic(uint256)` risk bitmap, the `EOFBytecodeNotSupported()` selector). A dedicated EOF revert-path case was added to each file alongside the existing success / `Metamorphic` cases.

## Mutation validation (adversarial discipline)

Each strengthened behavior was validated by mutating the concrete source (the regression site the issue names) and confirming the covering test FAILS, then restoring:

| Behavior | Mutation in `Extrospect.sol` | Result |
| --- | --- | --- |
| `Metamorphic` payload bitmap | `checkNotMetamorphic` reverts `Metamorphic(riskyOpcodes ^ 1)` | Revert + Fuzz FAIL on returndata mismatch (`...0001` vs `...0000`); EOF/Pass stay green |
| EOF selector (checkNotMetamorphic) | EOF path reverts `"EOF"` | EOF + Fuzz FAIL on selector mismatch (`0x08c379a0` vs `0x6facd91b`); Pass/Revert green |
| EOF selector (present-scan) | EOF path reverts `"EOF"` | EOF + Fuzz FAIL on selector mismatch; Concrete green |
| present-scan success value | `... ^ 1` on return | Concrete + Fuzz FAIL on value mismatch; EOF green |
| reachable-scan success value | `... ^ 1` on return | Concrete + Fuzz FAIL; EOF green |
| scanMetamorphicRisk success value | `... ^ 1` on return | WithDelegatecall + Fuzz FAIL; EOF green |

Every mutation fails exactly the test(s) covering that behavior and leaves the rest green. All source mutations restored; tree clean.

## Verification

- `forge build`: clean
- `forge test`: 304 passed. The only 3 failures are pre-existing fork tests in `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` that require `ARBITRUM_RPC_URL` (unrelated to this change).

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)