### PR TITLE
Add EIP-1967 proxy slot readers (Foundry test utility)

### DIFF
--- a/test/concrete/ERC1967ProxyFixture.sol
+++ b/test/concrete/ERC1967ProxyFixture.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {
+    ERC1967_IMPLEMENTATION_SLOT,
+    ERC1967_ADMIN_SLOT,
+    ERC1967_BEACON_SLOT
+} from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
+
+/// @dev Proxy test fixture that writes the three EIP-1967 slots in its
+/// constructor, giving a known storage layout to read back. Stores each
+/// address right-aligned in its 32-byte slot, matching how an EIP-1967
+/// proxy lays out the slots. The constructor arguments fix the exact
+/// address each slot holds so a test can assert the reader returns them.
+contract ERC1967ProxyFixture {
+    constructor(address implementation, address admin, address beacon) {
+        bytes32 implementationSlot = ERC1967_IMPLEMENTATION_SLOT;
+        bytes32 adminSlot = ERC1967_ADMIN_SLOT;
+        bytes32 beaconSlot = ERC1967_BEACON_SLOT;
+        //forge-lint: disable-next-line(assembly-usage)
+        assembly ("memory-safe") {
+            sstore(implementationSlot, implementation)
+            sstore(adminSlot, admin)
+            sstore(beaconSlot, beacon)
+        }
+    }
+}

--- a/test/lib/LibExtrospectERC1967ProxySlots.sol
+++ b/test/lib/LibExtrospectERC1967ProxySlots.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Vm} from "forge-std-1.16.1/src/StdCheats.sol";
+import {
+    ERC1967_IMPLEMENTATION_SLOT,
+    ERC1967_ADMIN_SLOT,
+    ERC1967_BEACON_SLOT
+} from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
+
+/// @title LibExtrospectERC1967ProxySlots
+/// @notice Foundry-only test utilities that read the three EIP-1967
+/// proxy storage slots of an arbitrary address via `vm.load`.
+///
+/// ERC-1967 specifies the implementation, admin and beacon storage
+/// slots but no public getter for any of them: a proxy routes every
+/// call through `delegatecall`, so no function selector exposes the
+/// slot. Direct reads come from `vm.load` (tests), an off-chain
+/// `eth_getStorageAt`, or `sload` from a delegatecall context running
+/// as the proxy. This library is the `vm.load` route, packaged so
+/// consumers writing their own Foundry tests have a single canonical
+/// reader for all three slots rather than re-deriving slot addresses
+/// and address decoding at each call site.
+///
+/// Each slot stores an address right-aligned in a 32-byte word, so the
+/// reader returns the low 160 bits as `address`. The slot constants
+/// are imported from `LibExtrospectERC1967BeaconProxy` so this reader
+/// and the on-chain library share one source for the slot addresses.
+library LibExtrospectERC1967ProxySlots {
+    /// @notice Read `proxy`'s EIP-1967 implementation slot.
+    /// @param vm The Foundry cheatcode interface.
+    /// @param proxy The proxy address whose storage is read.
+    /// @return The address stored in the implementation slot. Zero if
+    /// the slot was never written (e.g. the address is not an
+    /// EIP-1967 proxy).
+    function erc1967Implementation(Vm vm, address proxy) internal view returns (address) {
+        return address(uint160(uint256(vm.load(proxy, ERC1967_IMPLEMENTATION_SLOT))));
+    }
+
+    /// @notice Read `proxy`'s EIP-1967 admin slot.
+    /// @param vm The Foundry cheatcode interface.
+    /// @param proxy The proxy address whose storage is read.
+    /// @return The address stored in the admin slot. Zero if the slot
+    /// was never written (e.g. the address is not an EIP-1967 proxy,
+    /// or is a beacon proxy that has no admin).
+    function erc1967Admin(Vm vm, address proxy) internal view returns (address) {
+        return address(uint160(uint256(vm.load(proxy, ERC1967_ADMIN_SLOT))));
+    }
+
+    /// @notice Read `proxy`'s EIP-1967 beacon slot.
+    /// @param vm The Foundry cheatcode interface.
+    /// @param proxy The proxy address whose storage is read.
+    /// @return The address stored in the beacon slot. Zero if the slot
+    /// was never written (e.g. the address is not an EIP-1967 beacon
+    /// proxy).
+    function erc1967Beacon(Vm vm, address proxy) internal view returns (address) {
+        return address(uint160(uint256(vm.load(proxy, ERC1967_BEACON_SLOT))));
+    }
+}

--- a/test/src/lib/LibExtrospectERC1967ProxySlots.t.sol
+++ b/test/src/lib/LibExtrospectERC1967ProxySlots.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibExtrospectERC1967ProxySlots} from "test/lib/LibExtrospectERC1967ProxySlots.sol";
+import {ERC1967ProxyFixture} from "test/concrete/ERC1967ProxyFixture.sol";
+import {EmptyContract} from "test/concrete/EmptyContract.sol";
+
+/// @title LibExtrospectERC1967ProxySlotsTest
+/// @notice Tests `LibExtrospectERC1967ProxySlots` reads each EIP-1967
+/// proxy slot back to the exact address written.
+contract LibExtrospectERC1967ProxySlotsTest is Test {
+    /// Each reader returns the exact address the fixture wrote to its
+    /// slot. The three addresses are distinct so a reader that read the
+    /// wrong slot would return a different value.
+    function testReadsKnownSlotLayout() external {
+        address implementation = address(0x1111111111111111111111111111111111111111);
+        address admin = address(0x2222222222222222222222222222222222222222);
+        address beacon = address(0x3333333333333333333333333333333333333333);
+        ERC1967ProxyFixture proxy = new ERC1967ProxyFixture(implementation, admin, beacon);
+
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Implementation(vm, address(proxy)), implementation);
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Admin(vm, address(proxy)), admin);
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Beacon(vm, address(proxy)), beacon);
+    }
+
+    /// Fuzzed layout: each reader returns the exact address written to
+    /// its own slot, independent of the other two.
+    function testReadsFuzzedSlotLayout(address implementation, address admin, address beacon) external {
+        ERC1967ProxyFixture proxy = new ERC1967ProxyFixture(implementation, admin, beacon);
+
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Implementation(vm, address(proxy)), implementation);
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Admin(vm, address(proxy)), admin);
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Beacon(vm, address(proxy)), beacon);
+    }
+
+    /// A non-proxy never wrote the slots, so every reader returns the
+    /// zero address the slot defaults to.
+    function testReadsZeroFromNonProxy() external {
+        EmptyContract notAProxy = new EmptyContract();
+
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Implementation(vm, address(notAProxy)), address(0));
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Admin(vm, address(notAProxy)), address(0));
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Beacon(vm, address(notAProxy)), address(0));
+    }
+
+    /// Reading a slot only reflects that slot: a layout where only one
+    /// slot is set leaves the other two zero. Pins that the readers do
+    /// not alias each other's slot.
+    function testReadsOnlyImplementationSlot() external {
+        address implementation = address(0x4444444444444444444444444444444444444444);
+        ERC1967ProxyFixture proxy = new ERC1967ProxyFixture(implementation, address(0), address(0));
+
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Implementation(vm, address(proxy)), implementation);
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Admin(vm, address(proxy)), address(0));
+        assertEq(LibExtrospectERC1967ProxySlots.erc1967Beacon(vm, address(proxy)), address(0));
+    }
+}


### PR DESCRIPTION
## What

Adds `LibExtrospectERC1967ProxySlots`, a Foundry-only test utility that reads the three EIP-1967 proxy storage slots — implementation, admin, beacon — of an arbitrary address via `vm.load`, returning the stored address.

This implements option (a) from #24: ship test-utility wrappers around `vm.load` for the three slots, useful to consumers writing their own tests. ERC-1967 specifies these slots but no public getter, so a contract cannot read a proxy's slots from outside (#24 calls that out of scope — impossible in pure on-chain Solidity). The three direct-read routes are `vm.load` (tests), off-chain `eth_getStorageAt`, and `sload` from a delegatecall context running as the proxy. This packages the `vm.load` route behind one reader per slot.

The slot constants (`ERC1967_IMPLEMENTATION_SLOT`, `ERC1967_ADMIN_SLOT`, `ERC1967_BEACON_SLOT`) are imported from `LibExtrospectERC1967BeaconProxy` (added in #22) so the reader and the on-chain library share one canonical source for the slot addresses.

## Files

- `test/lib/LibExtrospectERC1967ProxySlots.sol` — the reader library (`erc1967Implementation` / `erc1967Admin` / `erc1967Beacon`).
- `test/concrete/ERC1967ProxyFixture.sol` — fixture that writes the three slots in its constructor, giving a known storage layout to read back.
- `test/src/lib/LibExtrospectERC1967ProxySlots.t.sol` — tests: known fixed layout, fuzzed layout (2048 runs), zero-default from a non-proxy, and single-slot-only (each reader does not alias another's slot).

## Mutation validation

| Mutation | Killed by |
| --- | --- |
| `ERC1967_IMPLEMENTATION_SLOT` derivation `-1` → `-2` | `testImplementationSlotMatchesDerivation` (existing slots test) |
| `erc1967Implementation` reads admin slot | `testReadsKnownSlotLayout`, `testReadsOnlyImplementationSlot`, `testReadsFuzzedSlotLayout` |
| `erc1967Admin` reads beacon slot | `testReadsKnownSlotLayout`, `testReadsFuzzedSlotLayout` |
| `erc1967Beacon` reads implementation slot | `testReadsOnlyImplementationSlot`, `testReadsFuzzedSlotLayout` |

All mutations restored after validation.

## Test result

`forge build` clean. `forge test`: 303 passed, 3 failed — the 3 failures are the pre-existing `ARBITRUM_RPC_URL` fork tests in `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` (missing RPC env, unrelated to this change), identical to baseline.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)