### PR TITLE
deps: bump rain-math-binary 0.1.1 -> 0.1.3

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,7 +21,7 @@ runs = 2048
 [dependencies]
 forge-std = "1.16.1"
 "rain-solmem" = "0.1.3"
-"rain-math-binary" = "0.1.1"
+"rain-math-binary" = "0.1.3"
 "rain-deploy" = "0.1.3"
 
 [soldeer]

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -14,10 +14,10 @@ integrity = "10bff708d9e5d8b77655b8a8fc0c755cef8e3fc876cc3ff100425d27b08294a0"
 
 [[dependencies]]
 name = "rain-math-binary"
-version = "0.1.1"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-binary/0_1_1_09-05-2026_19:49:57_rain.math.zip"
-checksum = "6f966e4f5f59103b62de2004005db508824622495b893a646d0e2a35511f0093"
-integrity = "4cfaa11c0e48ac46824a10fec2184863d114f09c171544b721d782386708dca7"
+version = "0.1.3"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-binary/0_1_3_19-07-2026_19:05:36_rain.math.zip"
+checksum = "0e9bd1e311999215baea944a292e241d1ed40ff9649c693cc9f125c9145808ab"
+integrity = "43557e24ad5bff04079460e5f1a550087df5b47f04fa63ff18c713fcec6a8289"
 
 [[dependencies]]
 name = "rain-solmem"

--- a/test/src/lib/EVMOpcodes.t.sol
+++ b/test/src/lib/EVMOpcodes.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibCtPop} from "rain-math-binary-0.1.1/src/lib/LibCtPop.sol";
+import {LibCtPop} from "rain-math-binary-0.1.3/src/lib/LibCtPop.sol";
 
 import {
     EVM_OP_STOP,


### PR DESCRIPTION
## What

Bumps `rain-math-binary` from **0.1.1 → 0.1.3** in `foundry.toml`, updates the versioned import prefix, and re-resolves `soldeer.lock`.

## Why

The audit graph flags `rain.extrospection` with a stale `rain-math-binary` dep (pinned 0.1.1, latest 0.1.3). Verified it's a **real** dependency, not a graph artifact:

- declared in `foundry.toml` `[dependencies]`
- actually used: `import {LibCtPop} from "rain-math-binary-0.1.1/src/lib/LibCtPop.sol"` in `test/src/lib/EVMOpcodes.t.sol`
- 0.1.3 is published on the soldeer registry (0.1.0–0.1.3, none deleted)

## Risk: none

`LibCtPop.sol` is **identical** between 0.1.1 and 0.1.3 except for added NatSpec (`@param`/`@return` docs and an expanded `@dev` note on the ctpop multiply constant). No API or behavior change. Usage is **test-only** — the published `src/` surface is unaffected.

## Verification

`forge build` clean; `forge test` → **308 passed, 3 failed**. The 3 failures are all `vm.createSelectFork: environment variable `ARBITRUM_RPC_URL` not found` in `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` — fork tests that need RPC secrets absent from my local env, in a file that doesn't touch `LibCtPop`. CI has the secrets.

## Note for future bumps

`forge soldeer install` obeys `soldeer.lock` and silently keeps the old version after a `foundry.toml` edit (it then fails the remappings step looking for the un-fetched dir). `forge soldeer update` is what re-resolves and rewrites the lock.

## Also flagged on this node (not in this PR)

The graph also lists `rain.deploy` 0.1.3 → 0.1.4 as stale for this repo — left for a separate focused PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying mathematical support components to improve compatibility and maintainability.
  * Refreshed validation coverage to ensure existing opcode and popcount behavior remains consistent.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->