### PR TITLE
test: ERC1167 implementation address mask (adversarial mutation batch erc1167)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,0 @@
-/nix/store/lm6f18alhwp2crdaimsvr09bg58pndfc-pre-commit-config.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,1 @@
+/nix/store/lm6f18alhwp2crdaimsvr09bg58pndfc-pre-commit-config.json

--- a/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
+++ b/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
@@ -165,6 +165,21 @@ contract LibExtrospectERC1167ProxyTest is Test {
         assertEq(ERC1167_PROXY_LENGTH, 45);
     }
 
+    /// The implementation address must be masked to exactly 160 bits. The word
+    /// loaded from bytecode also contains the final byte of the ERC1167 prefix
+    /// (0x73, the PUSH20 opcode) immediately above the address, so an unmasked
+    /// or under-masked read leaks it into the returned value.
+    function testIsERC1167ProxyImplementationAddressIsCleanWord(address implementation) external pure {
+        bytes memory bytecode = abi.encodePacked(ERC1167_PREFIX, implementation, ERC1167_SUFFIX);
+        (bool result, address implementationResult) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertTrue(result);
+        uint256 raw;
+        assembly ("memory-safe") {
+            raw := implementationResult
+        }
+        assertEq(raw, uint256(uint160(implementation)));
+    }
+
     /// Gas cost of the fast implementation succeeding.
     function testIsERC1167ProxyGasSuccess() external pure {
         (bool result, address implementationResult) = LibExtrospectERC1167Proxy.isERC1167Proxy(


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/73

Adversarial mutation pass over `LibExtrospectERC1167Proxy.isERC1167Proxy` (batch `erc1167`), at 28017b6.

13 targeted mutants, one per behaviour: the exact-length guard and its early return, PREFIX_START/LENGTH/HASH, SUFFIX_START/LENGTH/HASH, both `and(result, eq(keccak256..))` accumulations, the `if (result)` gate, IMPLEMENTATION_ADDRESS_OFFSET, and the uint160 mask.

12 were already killed by the pre-existing suite. One survived: widening the mask to `type(uint168).max` changed no observable value under any existing test, even though it leaks the final prefix byte (0x73, PUSH20) into the returned implementation address.

Test-only, additive.

Note for whoever owns the bytecode-pin batch: `ExtrospectConstantsTest` (testExtrospectCreationBytecode / testExtrospectRuntimeCodehash) fails under ANY source edit, so it "kills" every mutant in the repo and hides real gaps. This mask gap was invisible until those two were excluded from the probe suite. Separately, `LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest` fuzz tests fail intermittently on an EIP-7702 delegation designator that `vm.etch` rejects.

## QA
- Discriminating tests: `testIsERC1167ProxyImplementationAddressIsCleanWord` - fails on base with the mask widened to uint168 (the raw returned word carries 0x73 in bits 160-167), passes on correct code; verified with mutation-probe `--only M13`.
- Mutations applied: `uint256 implementationAddressMask = type(uint160).max;` -> `type(uint168).max` -> killed by `testIsERC1167ProxyImplementationAddressIsCleanWord`. All 12 other behaviours probed and killed by pre-existing tests (length guard `!=` -> `<` -> testIsERC1167ProxyLength46; early return `(false,0)` -> `(true,0)` -> testIsERC1167ProxyLength/Length44/Length46; prefix start/length/hash and suffix start/length/hash each perturbed -> testIsERC1167ProxySuccess + testIsERC1167ProxySlowSuccess; prefix accumulation `and` -> `or` -> testIsERC1167ProxyPrefixFail45Bytes; suffix accumulation `and` -> `or` -> testIsERC1167ProxySuffixFail45Bytes; `if (result)` -> `if (true)` -> testIsERC1167ProxyBothPrefixAndSuffixFail; address offset -1 -> testIsERC1167ProxySuccess).
- Oracle: EIP-1167 itself - the runtime is 10 prefix bytes, 20 address bytes, 15 suffix bytes, so the implementation address is exactly 160 bits and nothing above bit 159 belongs to it. The expected value is `uint160(implementation)`, the address the test itself built the bytecode from, not a value read back out of the implementation.
- Category check: batch scope is the 13 behaviours of isERC1167Proxy listed above; all enumerated, all probed, one gap found and closed.