### PR TITLE
test: pin ERC-1967 beacon _tryGetAddress success-flag check

### DIFF
--- a/test/concrete/RevertingWithAddressBeacon.sol
+++ b/test/concrete/RevertingWithAddressBeacon.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @dev The address every `RevertingWithAddressBeacon` puts in its
+/// revert data. It has no code, so its runtime bytecode hashes to
+/// `keccak256("")`.
+address constant REVERTING_WITH_ADDRESS_BEACON_PAYLOAD = address(uint160(0x1234));
+
+/// @dev Beacon test fixture whose `implementation()` and `owner()`
+/// revert with exactly 32 bytes of revert data that decode cleanly as
+/// an address. A failed call still leaves `returndata` populated, so
+/// the length check and the dirty-bits check both pass on it: only the
+/// `success` flag distinguishes this from a successful call. Pins that
+/// `_tryGetAddress` reads the staticcall's success flag rather than
+/// inferring failure from the shape of the returned bytes.
+contract RevertingWithAddressBeacon {
+    function implementation() external pure returns (address) {
+        _revertWithAddress();
+    }
+
+    function owner() external pure returns (address) {
+        _revertWithAddress();
+    }
+
+    /// @dev Reverts with the 32-byte word holding
+    /// `REVERTING_WITH_ADDRESS_BEACON_PAYLOAD`, right-aligned and with
+    /// zero upper bits — byte-identical to a successful `address`
+    /// return.
+    function _revertWithAddress() internal pure {
+        address payload = REVERTING_WITH_ADDRESS_BEACON_PAYLOAD;
+        //forge-lint: disable-next-line(assembly-usage)
+        assembly ("memory-safe") {
+            mstore(0, payload)
+            revert(0, 0x20)
+        }
+    }
+}

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
@@ -9,6 +9,10 @@ import {EmptyContract} from "test/concrete/EmptyContract.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
+import {
+    RevertingWithAddressBeacon,
+    REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
+} from "test/concrete/RevertingWithAddressBeacon.sol";
 
 /// @title LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest
 /// @notice Tests `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`.
@@ -107,6 +111,19 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
     /// start of an empty `string memory` encoding.
     function testReturnsFalseOnWrongLengthReturn() external {
         WrongLengthBeacon beacon = new WrongLengthBeacon();
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+    }
+
+    /// A beacon whose `implementation()` reverts with exactly 32 bytes
+    /// that decode cleanly as an address must still fail the predicate.
+    /// The revert data is byte-identical to a successful `address`
+    /// return, so only the staticcall's `success` flag separates the
+    /// two: a wrapper that ignored `success` would decode
+    /// `REVERTING_WITH_ADDRESS_BEACON_PAYLOAD`, whose (absent) code
+    /// hashes to `keccak256("")`, and return true here.
+    function testReturnsFalseOnRevertWithAddressSizedData() external {
+        RevertingWithAddressBeacon beacon = new RevertingWithAddressBeacon();
+        assertEq(keccak256(REVERTING_WITH_ADDRESS_BEACON_PAYLOAD.code), keccak256(""));
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
     }
 }

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
@@ -9,6 +9,10 @@ import {EmptyContract} from "test/concrete/EmptyContract.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
+import {
+    RevertingWithAddressBeacon,
+    REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
+} from "test/concrete/RevertingWithAddressBeacon.sol";
 
 /// @title LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest
 /// @notice Tests `LibExtrospectERC1967BeaconProxy.isBeaconOwner`.
@@ -81,5 +85,19 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest is Test {
     function testReturnsFalseOnWrongLengthReturn() external {
         WrongLengthBeacon beacon = new WrongLengthBeacon();
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), address(uint160(0x20))));
+    }
+
+    /// A beacon whose `owner()` reverts with exactly 32 bytes that
+    /// decode cleanly as an address must still fail the predicate. The
+    /// revert data is byte-identical to a successful `address` return,
+    /// so only the staticcall's `success` flag separates the two: a
+    /// wrapper that ignored `success` would report
+    /// `REVERTING_WITH_ADDRESS_BEACON_PAYLOAD` as the owner and return
+    /// true here.
+    function testReturnsFalseOnRevertWithAddressSizedData() external {
+        RevertingWithAddressBeacon beacon = new RevertingWithAddressBeacon();
+        assertFalse(
+            LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), REVERTING_WITH_ADDRESS_BEACON_PAYLOAD)
+        );
     }
 }


### PR DESCRIPTION
Adversarial mutation pass over `LibExtrospectERC1967BeaconProxy` (batch: erc1967), probed against the pre-existing suite at 28017b6 with `mutation-probe`.

16 mutants, one per enumerated behaviour: both predicates' `ok &&` guard and their comparison, `_tryGetAddress`'s success flag / `length != 32` (both directions) / dirty-bits check (drop and boundary) / mload offset (two offsets), and the three ERC-1967 slot constants (off-by-one and preimage string).

15 were killed by existing tests. One survived: deleting the `!success` check in `_tryGetAddress`. A revert still leaves returndata, so a beacon that reverts with exactly 32 clean address bytes passes both the length and dirty-bits checks — nothing in the suite distinguished it from a successful call.

Test-only, additive: adds `test/concrete/RevertingWithAddressBeacon.sol` and one discriminating test per predicate.

## QA
- Discriminating tests: `LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest.testReturnsFalseOnRevertWithAddressSizedData`, `LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest.testReturnsFalseOnRevertWithAddressSizedData` — each asserts a DIFFERENT boolean under correct vs mutated code (false vs true), verified by re-probing mutant M05 with `mutation-probe --only M05`: SURVIVED before these tests, KILLED by them after.
- Mutations applied (`src/lib/LibExtrospectERC1967BeaconProxy.sol`, killers named from the ERC-1967 suite):
  - M01 `return ok && keccak256(impl.code) == expected` -> drop `ok &&` -> `testReturnsFalseOnNoCodeTarget`, `testReturnsFalseOnNonBeaconWithEmptyHash`, `testReturnsFalseOnWrongLengthReturn`
  - M02 same line -> drop hash comparison (`return ok;`) -> KILLED (fuzz tests `testMismatches` / `testImplementationZeroAddressHashesToEmpty`)
  - M03 `return ok && own == expectedOwner` -> drop `ok &&` -> `testReturnsFalseOnNonOwnableWithZeroAddress`
  - M04 same line -> drop equality (`return ok;`) -> KILLED (fuzz `testMismatches`)
  - M05 `if (!success || returnData.length != 32)` -> drop `!success` -> SURVIVED -> now `testReturnsFalseOnRevertWithAddressSizedData`
  - M06 same line -> `length > 32` (accept short) -> `testReturnsFalseOnNoCodeTarget`
  - M07 same line -> `length < 32` (accept long) -> `testReturnsFalseOnWrongLengthReturn`
  - M08 `if (raw > type(uint160).max)` -> never taken -> KILLED (fuzz `testReturnsFalseOnInvalidReturnEncoding`)
  - M09 same line -> `>=` -> `testMatchesAtMaxAddressBoundary`
  - M10 `raw := mload(add(returnData, 0x20))` -> `mload(returnData)` -> `testMatches`, `testMatchesAtMaxAddressBoundary`
  - M11 same line -> `mload(add(returnData, 0x40))` -> `testMatches`, `testMatchesAtMaxAddressBoundary`
  - M12 / M15 implementation slot: `- 2`, and preimage `"eip1967.proxy.implementation2"` -> `testImplementationSlotMatchesDerivation`
  - M13 admin slot `- 1 + 1` -> `testAdminSlotMatchesDerivation`
  - M14 / M16 beacon slot `- 3`, preimage `"eip1967.proxy.beaconx"` -> `testBeaconSlotMatchesDerivation`
- Oracle: the EVM call contract, not the implementation. The new tests' expected value comes from the spec statement that a reverted call yields no value; the revert payload is chosen so every OTHER check in the function passes on it, so `false` can only come from reading the staticcall's success flag. `keccak256("")` is asserted equal to `keccak256(PAYLOAD.code)` inside the test rather than assumed.
- Category check: batch scope is the 11 named behaviours of `LibExtrospectERC1967BeaconProxy`; all 11 probed (16 mutants — the extras cover both directions of the length check and the boundary/offset variants). No other unit touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
