### PR TITLE
Move soldeer release metadata under foundry's [external] section

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,8 @@
-[package]
+# Release metadata, not foundry config. `rainix-autopublish` reads `version` as
+# the next, unpublished Soldeer release and rewrites the line when it publishes.
+# `[external.*]` is the section foundry reserves for another tool's config and
+# ignores.
+[external.package]
 name = "rain-extrospection"
 version = "0.1.6"
 


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/49

`foundry.toml` opened with a bare `[package]`. foundry reads any root section it
does not reserve as a profile, so every `forge` invocation in this repo printed:

```
Warning: Found unknown config section in foundry.toml: [package]
This notation for profiles has been deprecated and may result in the profile not being registered in future versions.
Please use [profile.package] instead or run `forge config --fix`.
```

Reproduced on `origin/main` (`32f7325`) with this repo's own pinned toolchain
before anything was changed.

The section is now `[external.package]` — the section foundry reserves for
another tool's config and ignores. On this branch `forge config` prints no
`[package]` warning, and its resolved-config stdout is byte-identical to main's.

## No verdict moves

`src/` is untouched; this is a build-config section name and a comment. Nothing
this library concludes about any contract changes. The suite proves it: the full
run is identical before and after (below).

## Publishing is untouched — measured, not asserted

- **`foundry.toml` is not in the published package at all.** `.soldeerignore`
  lists `/foundry.toml`, and grepping the `forge soldeer push --dry-run` zip for
  the name finds zero entries. The section it declares cannot reach the content
  hash by any route.
- **`rainix-static soldeer-gate`, run for real** from the rainix SHA `53e96a7d`
  that `rainix-autopublish.yaml` pins, on two pristine trees differing only in
  that section name:

  ```
  [external.package]: remote=0.1.6 publish=0.1.7 next=0.1.8 OLD=1d76fe69… NEW=4901a6de… changed=true
  [package]:          remote=0.1.6 publish=0.1.7 next=0.1.8 OLD=1d76fe69… NEW=4901a6de… changed=true
  ```

  Byte-identical published version, next version and content hash. Both probes
  were set to `0.1.7` because the gate's next-version invariant refuses `0.1.6`
  — see "Live release state" below. `changed=true` on both sides is the same
  answer, not a difference.
- **`forge soldeer push rain-extrospection~0.1.6 --dry-run` succeeds** against
  the new section. soldeer does not read `[package]`; the spec comes from the
  command line.
- **The gate's version reader is section-unaware.** `read_local_version` and
  `is_version_line` in `rainix-static/src/soldeer_gate.rs` scan for the first
  line whose `strip_prefix("version")` is followed by `=`, and the autopublish
  bump `sed` anchors the same way (`0,/^version[[:space:]]*=.*/`).
  `foundry.toml` has exactly one such line and it stays unindented and first in
  the section.

## Mutation pass

Every mutant applied to `foundry.toml` on this branch, restored to a clean tree
after each — verified: `git status --short foundry.toml` empty at the end of
both runs. Detectors are the three things that actually consume this file.

| # | Mutant | Detector | Result | Observed |
|---|---|---|---|---|
| M1 | `[external.package]` to `[package]` (revert to main) | `forge config` stderr | KILLED | `Found unknown config section in foundry.toml: [package]` |
| M2 | `[external.package]` to `[profile.package]` (what `--fix` writes) | `forge config` stderr | KILLED | **two** warnings — unknown `name` config for profile `package`, and the same for `version` |
| M3 | `[external.package]` to `[externalpackage]` (near-miss on the reserved prefix) | `forge config` stderr | KILLED | `Found unknown config section in foundry.toml: [externalpackage]` — it is the `external.` prefix that is reserved, not the substring |
| M4 | indent the `version` line under the section | `rainix-static soldeer-gate` | KILLED | `::error::foundry.toml has no [package].version`, exit 1 — fails loud, never a bad publish |
| M5 | delete the `name` line | `forge soldeer push --dry-run`, `forge config` | **SURVIVED** | push exits 0, forge silent — see below |
| M6 | `version` to `0.1.7`, under each section name | `rainix-static soldeer-gate` | KILLED | gate advances to `publish=0.1.7 next=0.1.8` identically under both names |
| M7 | run `forge config --fix` on the branch file | file contents | KILLED | `[external.package]` left byte-identical; the same `--fix` on main's file rewrites `[package]` to `[profile.package]`, and the result then warns twice |

**M5 survives and is not fixed here.** Nothing in the pipeline reads
`[external.package].name`: `forge soldeer push` takes `name~version` on the
command line, and `.github/workflows/package-release.yaml` passes
`soldeer-package: rain-extrospection` to the reusable explicitly. It is inert
metadata both before and after this PR — a pre-existing property of the section,
not something this change introduces, and removing it is not what the issue
asks for. Reported, not touched.

## Checks

- `forge config`: `[package]` warning on `origin/main` (`32f7325`), absent on
  this branch. Resolved-config stdout `diff` between the two: identical.
- `forge test`, same command both ways:
  `27 test suites, 311 tests passed, 3 failed, 0 skipped (314 total)` on
  `origin/main` and on this branch. The 3 failures are
  `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol`'s fork
  tests failing on `environment variable ARBITRUM_RPC_URL not found` — a missing
  local secret, present identically on both sides, and the subject of
  https://github.com/rainlanguage/rain.extrospection/issues/85. No test file was
  excluded for this PR: with no source mutation there is nothing for
  `ExtrospectConstantsTest`'s pinned-bytecode assertions to false-positive on,
  so the whole suite ran.
- `forge fmt --check` exit 0. `taplo`, the repo's TOML formatter via pre-commit,
  passed on the changed file.
- CI on this branch (`rainix-sol`, run 32140520748): `legal`, `static` and
  `test` all pass. The `test` job, which has `ARBITRUM_RPC_URL`, reports
  `27 test suites, 314 tests passed, 0 failed, 0 skipped (314 total)` — the
  same 314 tests, with the 3 fork tests running instead of erroring.

## Live release state, unrelated to this PR

`soldeer-gate` currently fails on `origin/main` as well as on this branch, with
the same message both ways:

```
::error::foundry.toml [package].version (0.1.6) is not ahead of the published revision (0.1.6)
```

`rain-extrospection~0.1.6` is already on the registry, published 2026-08-18
12:57, but `foundry.toml` on main still says `0.1.6` — the publish landed and
the bump commit did not. That is a pre-existing condition of the release
pipeline. This PR does not touch the `version` line.

## QA

- Discriminating tests: n/a as a Solidity test — `test/src/**` mirrors `src/**` by subject, and this release-metadata section has no `src/` counterpart, so there is nowhere in the mirror tree a test for it belongs; the ruling also forbids tests that assert prose or config text. The discriminating check is a command run both ways: `nix develop -c forge config` prints `Found unknown config section in foundry.toml: [package]` on `origin/main` (`32f7325`) and prints no such warning on this branch, with identical resolved-config stdout.
- Mutations applied: seven, table above. `[external.package]` -> `[package]` -> killed by `forge config` stderr; `[external.package]` -> `[profile.package]` -> killed by `forge config` stderr (two warnings); `[external.package]` -> `[externalpackage]` -> killed by `forge config` stderr; `version = "0.1.6"` -> indented `  version = "0.1.6"` -> killed by `rainix-static soldeer-gate` (`::error::foundry.toml has no [package].version`, exit 1); `version` -> `0.1.7` under both section names -> killed by `soldeer-gate` (`publish=0.1.7 next=0.1.8`, identical under both); `forge config --fix` applied -> killed (leaves `[external.package]` byte-identical, rewrites `[package]` to `[profile.package]`); delete `name = "rain-extrospection"` -> **SURVIVED**, nothing in the pipeline reads it, reported above and deliberately not fixed.
- Oracle: the three real consumers of this file at their pinned versions, not the warning text — `forge` from this repo's own `flake.lock` (rainix `f22d4dca`, foundry.nix `db117ae9`) for whether a section warns and whether `--fix` rewrites it; `rainix-static/src/soldeer_gate.rs` (`read_local_version`, `is_version_line`, `norm_hash`, `blank_foundry_version`) at rainix `53e96a7d`, the SHA `rainix-autopublish.yaml` pins, for what the release reads; `.soldeerignore` plus the actual dry-run zip for what is published.
- Category check: the issue asks for one change — rename `[package]` to `[external.package]`, keep `version` unindented and first in the section, add a comment saying the section is another tool's metadata, and fix any prose naming `[package].version`. All covered: the rename and the comment are the diff; `version` is unindented and is the only `^version =` line in the whole file, which is exactly what both readers anchor on — `read_local_version` returns the first such line and the bump `sed` uses `0,/^version[[:space:]]*=.*/` (M4 covers the indent constraint); its position relative to `name` is not read by anything, so the section keeps main’s key order, as the `rain.sol.codegen` precedent did; and this repo's `README.md` and `CLAUDE.md` name no `[package]` section, so there is no prose to fix — grepping for `[package]` / `package.version` outside `dependencies/` now returns nothing. The issue's requested before/after `soldeer-gate` verification is under "Publishing is untouched" above.
