### PR TITLE
Describe HALTING_BITMAP membership accurately and cover the unassigned opcodes

### DIFF
--- a/src/lib/EVMOpcodes.sol
+++ b/src/lib/EVMOpcodes.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.25;
 
 /// @dev EVM opcode constants current through Cancun. Each constant is the
-/// canonical opcode byte value. Derived bitmaps: `HALTING_BITMAP` encodes
-/// opcodes that terminate the current execution path; `METAMORPHIC_OPS`
+/// canonical opcode byte value. Derived bitmaps: `HALTING_BITMAP` encodes the
+/// opcodes at which the reachability scan pauses; `METAMORPHIC_OPS`
 /// encodes opcodes that indicate metamorphic risk; `NON_STATIC_OPS` encodes
 /// opcodes disallowed by EIP-214 static calls; `INTERPRETER_DISALLOWED_OPS`
 /// encodes opcodes disallowed for Rain interpreters.
@@ -181,10 +181,12 @@ uint8 constant EVM_OP_REVERT = 0xFD;
 uint8 constant EVM_OP_INVALID = 0xFE;
 uint8 constant EVM_OP_SELFDESTRUCT = 0xFF;
 
-/// @dev Bitmap of opcodes that terminate the current execution path. Used by
-/// `LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode` to pause scanning
-/// until the next JUMPDEST. Includes STOP, RETURN, REVERT, INVALID,
-/// SELFDESTRUCT, and unconditional JUMP (which cannot fall through).
+/// @dev Bitmap of exactly six opcodes at which
+/// `LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode` pauses scanning
+/// until the next JUMPDEST: STOP, RETURN, REVERT, INVALID, SELFDESTRUCT, and
+/// unconditional JUMP (which cannot fall through). The byte values Cancun
+/// leaves unassigned (0x0C-0x0F, 0x1E-0x1F, 0x21-0x2F, 0x4B-0x4F, 0xA5-0xEF,
+/// 0xF6-0xF9, 0xFB, 0xFC) are not members, so the scan does not pause at them.
 //forge-lint: disable-next-line(incorrect-shift)
 uint256 constant HALTING_BITMAP = (1 << EVM_OP_STOP) | (1 << EVM_OP_RETURN) | (1 << EVM_OP_REVERT)
     //forge-lint: disable-next-line(incorrect-shift)

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -158,8 +158,9 @@ library LibExtrospectBytecode {
     /// INVALID, SELFDESTRUCT, or unconditional JUMP per `HALTING_BITMAP`),
     /// scanning pauses. Scanning resumes at the next JUMPDEST. Opcodes between
     /// a halt and the next JUMPDEST are treated as unreachable and excluded.
-    /// This is an over-approximation because not all JUMPDESTs are actually
-    /// reachable at runtime.
+    /// This is an over-approximation: not all JUMPDESTs are actually reachable
+    /// at runtime, and the byte values Cancun leaves unassigned other than
+    /// INVALID do not pause scanning even though the EVM halts on them.
     /// Adapted from https://github.com/MrLuit/selfdestruct-detect/blob/master/src/index.ts
     /// NOTE: Reverts with `EOFBytecodeNotSupported` if the bytecode is EOF
     /// (EIP-7692).

--- a/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
@@ -240,6 +240,34 @@ contract LibExtrospectScanEVMOpcodesReachableInBytecodeTest is Test {
         );
     }
 
+    /// The byte values Cancun leaves unassigned, excluding INVALID (0xFE).
+    function undefinedInCancun(uint256 op) internal pure returns (bool) {
+        return (op >= 0x0C && op <= 0x0F) || (op >= 0x1E && op <= 0x1F) || (op >= 0x21 && op <= 0x2F)
+            || (op >= 0x4B && op <= 0x4F) || (op >= 0xA5 && op <= 0xEF) || (op >= 0xF6 && op <= 0xF9) || op == 0xFB
+            || op == 0xFC;
+    }
+
+    /// Every byte Cancun leaves unassigned, other than INVALID, leaves the
+    /// scan running, so a SELFDESTRUCT placed directly after one is reported
+    /// as reachable.
+    function testScanEVMOpcodesReachableUndefinedDoesNotHalt() public pure {
+        uint256 undefinedCount = 0;
+        for (uint256 op = 0; op < 0x100; op++) {
+            if (!undefinedInCancun(op)) {
+                continue;
+            }
+            undefinedCount++;
+            assertEq(
+                LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(
+                    abi.encodePacked(uint8(op), EVM_OP_SELFDESTRUCT)
+                ),
+                (uint256(1) << op) | (uint256(1) << uint256(EVM_OP_SELFDESTRUCT)),
+                "undefined opcode halted the scan"
+            );
+        }
+        assertEq(undefinedCount, 107);
+    }
+
     /// PUSH0 (0x5F) is NOT a PUSH with data — it pushes zero with no inline
     /// bytes. The next byte is a separate opcode, not skip data.
     function testScanEVMOpcodesReachablePush0Boundary() public pure {


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/56

## What this is

The issue has two halves. This PR is the half that changes no verdict. The
other half — whether `HALTING_BITMAP` should gain the unassigned bytes — is a
decision about what the library concludes, so it is
[posted on the issue as an option space](https://github.com/rainlanguage/rain.extrospection/issues/56)
and deliberately not implemented here.

## Verified first

Reproduced against `main` (`32f7325`) in a fresh clone. `HALTING_BITMAP`
claimed to be "opcodes that terminate the current execution path" while
containing six bytes; of the byte values Cancun leaves unassigned — all of
which are exceptional halts on a real EVM — only `INVALID` is a member, so the
reachability scan keeps scoring bytes past the other 107.

The issue says "~50". The real count is **107**: `EVMOpcodes.sol` declares 149
opcode bytes and `256 - 149 = 107`, which is exactly the set the issue
enumerates. Only the prose number was wrong.

## Changes

- `src/lib/EVMOpcodes.sol` — the `HALTING_BITMAP` `@dev` no longer characterises
  the bitmap as the halting set. It states the six members, and states that the
  unassigned bytes are not members so the scan does not pause at them. Same
  correction to the file-level `@dev`.
- `src/lib/LibExtrospectBytecode.sol` — `scanEVMOpcodesReachableInBytecode`
  named one source of over-approximation (unreachable `JUMPDEST`s). It now
  names both.
- `test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol` —
  `testScanEVMOpcodesReachableUndefinedDoesNotHalt` walks every one of the 107
  unassigned bytes, each followed by `SELFDESTRUCT`, and asserts the reported
  reachable set. The range list is written out in the test rather than derived
  from `EVMOpcodes.sol`, and the count is asserted at 107 so a mistyped range
  fails rather than silently shrinking the test.

## No verdict moves

`ExtrospectConstantsTest` pins creation bytecode, the deterministic Zoltu
address and the runtime codehash. It **passes** on this branch, so the deployed
bytecode is bit-identical to `main` and no verdict can have changed.

```
Ran 3 tests for test/src/concrete/Extrospect.constants.t.sol:ExtrospectConstantsTest
[PASS] testExtrospectCreationBytecode() (gas: 2949)
[PASS] testExtrospectRuntimeCodehash() (gas: 1670)
[PASS] testExtrospectZoltuAddress()
```

Full run with only the RPC-dependent file excluded:

```
Ran 26 test suites in 950.94ms (11.51s CPU time): 308 tests passed, 0 failed, 0 skipped (308 total tests)
```

## Adversarial mutation pass

Exclusions and why:

- `test/src/concrete/Extrospect.constants.t.sol` — pins deployed bytecode, so it
  fails under **every** source mutation. Leaving it in reports KILLED for every
  mutant and measures nothing. Excluded for the mutation runs only; it is
  included in the clean run above.
- `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` —
  needs `ARBITRUM_RPC_URL`, which is not available in this environment (that is
  #85). Excluding the file drops 7 tests that would otherwise run 4 and skip 3.

Baseline under those exclusions, proving the harness runs and is green before
any mutant:

```
== baseline :: Ran 25 test suites: 305 tests passed, 0 failed, 0 skipped (305 total tests)
```

| # | Mutation | Site | Suite result | Killed by | |
|---|---|---|---|---|---|
| — | none (branch as submitted) | — | `305 passed, 0 failed, 0 skipped (305 total)` | — | baseline green |
| M1 | scan halts on `0xA5`-`0xEF` **without touching `HALTING_BITMAP`**: `if and(shl(op,1),haltingMask)` → `if or(and(shl(op,1),haltingMask), and(gt(op,0xA4),lt(op,0xF0)))` | `LibExtrospectBytecode.sol:197` | `302 passed, 3 failed (305 total)` | `testScanEVMOpcodesReachableUndefinedDoesNotHalt` (new), `testScanEVMOpcodesReachableReference` (fuzz), `testScanMetamorphicRiskReference` (fuzz) | KILLED |
| M2 | `HALTING_BITMAP` gains one unassigned byte: `\| (1 << 0xFB)` | `EVMOpcodes.sol:189` | `302 passed, 3 failed (305 total)` | `testHaltingBitmap`, `testHaltingBitmapPopcount`, `testScanEVMOpcodesReachableUndefinedDoesNotHalt` | KILLED |
| M3 | `HALTING_BITMAP` loses `(1 << EVM_OP_INVALID)` | `EVMOpcodes.sol:191` | `301 passed, 4 failed (305 total)` | `testHaltingBitmap`, `testHaltingBitmapIndividualBits`, `testHaltingBitmapPopcount`, `testScanEVMOpcodesReachableInvalid` | KILLED |
| M4 | `HALTING_BITMAP` loses `(1 << EVM_OP_JUMP)` | `EVMOpcodes.sol:194` | `301 passed, 4 failed (305 total)` | `testHaltingBitmap`, `testHaltingBitmapIndividualBits`, `testHaltingBitmapPopcount`, `testScanEVMOpcodesReachableJump` | KILLED |
| M5 | scan resumes at `TLOAD` (`0x5C`) instead of `JUMPDEST` | `LibExtrospectBytecode.sol:203` | `224 passed, 81 failed (305 total)` | 81 tests, including all six `checkNotMetamorphic` revert cases | KILLED |
| M6 | `JUMPDEST` clears `halted` but is not recorded as reachable | `LibExtrospectBytecode.sol:206` deleted | `303 passed, 2 failed (305 total)` | `testScanEVMOpcodesReachableJumpdest`, `testScanEVMOpcodesReachableReference` | KILLED |
| M7 | **oracle mutant** — drop `0xF6-0xF9` from the new test's own range list, source untouched | the new test | `304 passed, 1 failed (305 total)` | `testScanEVMOpcodesReachableUndefinedDoesNotHalt` (`103 != 107`) | KILLED |

Every row above is a real `forge test` run whose full output is quoted from the
run log, not a claim — each shows the suite total so a mutant that failed to
compile or silently matched zero tests would be visible as a missing or
zero-count line rather than a free KILLED.

Reading the table:

- **M1 is the mutant the new test exists for.** It changes halting behaviour
  without touching `HALTING_BITMAP`, so every bitmap assertion in
  `EVMOpcodes.t.sol` sails through it. Its only other killers are the two
  `*Reference` fuzz tests, and they kill it only because the slow reference
  reads the unmutated constant. A fuzz run is not a proof, so the deterministic
  test is what actually closes this hole.
- **M2 is the mirror image.** A constant-only mutation is invisible to both
  `*Reference` fuzz tests, because the fast and slow implementations read the
  same mutated constant and agree. It is caught by the bitmap tests and by the
  new test.
- **M7 mutates the test's own oracle rather than the source**, to show the
  range list is not self-fulfilling: shrink it and the `107` count assertion
  fires rather than the test quietly covering less.

The working tree was restored with `git checkout -- src test` after every
mutant and is clean at `HEAD`.

## QA
- Discriminating tests: `testScanEVMOpcodesReachableUndefinedDoesNotHalt` — fails on base under mutant M1 (halting condition widened to `0xA5-0xEF`: `undefined opcode halted the scan: 46768052394588893382517914646921056628989841375232 != 57896044618658097711785492551112006321223885715338196666649848632946406195200`), under M2 (`HALTING_BITMAP |= 1 << 0xFB`), and under its own oracle mutant M7 (`103 != 107`). It passes on unmutated `main` (`32f7325`) — that pass is what confirms the issue's claim; this PR changes no source behaviour for it to newly detect.
- Mutations applied: `LibExtrospectBytecode.sol:197` halting condition widened to `0xA5-0xEF` -> `testScanEVMOpcodesReachableUndefinedDoesNotHalt`; `EVMOpcodes.sol:189` `HALTING_BITMAP` gains `1 << 0xFB` -> `testHaltingBitmap`, `testHaltingBitmapPopcount`, the new test; `EVMOpcodes.sol:191` drops `INVALID` -> `testScanEVMOpcodesReachableInvalid` + 3 bitmap tests; `EVMOpcodes.sol:194` drops `JUMP` -> `testScanEVMOpcodesReachableJump` + 3 bitmap tests; `LibExtrospectBytecode.sol:203` resume at `0x5C` instead of `JUMPDEST` -> 81 tests; `LibExtrospectBytecode.sol:206` deleted so `JUMPDEST` is unrecorded -> `testScanEVMOpcodesReachableJumpdest`; test-oracle mutant dropping `0xF6-0xF9` from the new test's range list -> the new test's `107` count assertion. All 7 KILLED; full table above; baseline `305 passed, 0 failed, 0 skipped`.
- Oracle: the unassigned-byte ranges are written out literally in the test from the Cancun opcode assignment, not derived from `EVMOpcodes.sol`, so the test cannot agree with the source by construction. The expected scan result per byte is built by hand as `(1 << op) | (1 << SELFDESTRUCT)`, not by calling any scanner. The 107 count is cross-checked independently as `256 - 149` declared opcode constants.
- Category check: the issue asks (a) the `@dev` text asserts a closed list that is not the real halting set, and (b) whether the M01 consistency gap should be closed by enlarging `HALTING_BITMAP`. (a) is covered here — both `@dev` sites plus the `scanEVMOpcodesReachableInBytecode` NatSpec, with a test pinning the behaviour the corrected text describes. (b) is deliberately NOT covered: it changes what `checkNotMetamorphic` concludes, so the option space with measured effects is posted on the issue for a human decision.
