### PR TITLE
test(deploy): prove the pinned deploy record reproduces by execution

### DIFF
--- a/test/src/concrete/Extrospect.constants.t.sol
+++ b/test/src/concrete/Extrospect.constants.t.sol
@@ -55,4 +55,33 @@ contract ExtrospectConstantsTest is Test {
         bytes32 actual = keccak256(type(Extrospect).runtimeCode);
         assertEq(actual, EXTROSPECT_RUNTIME_CODEHASH_V1, "EXTROSPECT_RUNTIME_CODEHASH_V1 drifted from runtime bytecode");
     }
+
+    /// The three pinned constants describe one deployment, so they must agree
+    /// with each other when the pinned creation bytecode is actually executed.
+    /// Running it through the real Zoltu factory bytecode lands at
+    /// `EXTROSPECT_ZOLTU_ADDRESS_V1` and leaves code hashing to
+    /// `EXTROSPECT_RUNTIME_CODEHASH_V1`, and that runtime code is byte for byte
+    /// `type(Extrospect).runtimeCode`. Deterministic and offline: the factory is
+    /// etched from its own pinned bytecode, so no network is involved.
+    function testExtrospectDeployRecordReproduces() external {
+        LibRainDeploy.etchZoltuFactory(vm);
+
+        address deployed = LibRainDeploy.deployZoltu(EXTROSPECT_CREATION_BYTECODE_V1);
+
+        assertEq(
+            deployed,
+            EXTROSPECT_ZOLTU_ADDRESS_V1,
+            "pinned creation bytecode does not deploy to EXTROSPECT_ZOLTU_ADDRESS_V1"
+        );
+        assertEq(
+            deployed.codehash,
+            EXTROSPECT_RUNTIME_CODEHASH_V1,
+            "deployed runtime code does not hash to EXTROSPECT_RUNTIME_CODEHASH_V1"
+        );
+        assertEq(
+            deployed.code,
+            type(Extrospect).runtimeCode,
+            "deployed runtime code differs from type(Extrospect).runtimeCode"
+        );
+    }
 }


### PR DESCRIPTION
Part of https://github.com/rainlanguage/rain.extrospection/issues/44 — the check that issue names as its first step. **It does not close #44**: the per-release snapshot machinery is blocked on a dependency that does not exist in any published package. That blocker and its option space are posted on the issue; see the bottom of this body.

## What this lands

#44's first step, verbatim: *"regenerate and confirm the generated record reproduces the existing hardcoded literals byte for byte. If it does, the pins were right and the migration is safe."*

**It does.** Executing `EXTROSPECT_CREATION_BYTECODE_V1` through the Zoltu factory's own bytecode lands on `EXTROSPECT_ZOLTU_ADDRESS_V1`, leaves code hashing to `EXTROSPECT_RUNTIME_CODEHASH_V1`, and that code is byte for byte `type(Extrospect).runtimeCode`. No discrepancy to surface.

## The gap it closes

The three constants were each checked against the compiler on their own, and never against each other through the mechanism that actually deploys them:

| test | oracle |
|---|---|
| `testExtrospectCreationBytecode` | `keccak(pin) == keccak(type(Extrospect).creationCode)` |
| `testExtrospectZoltuAddress` | CREATE2 arithmetic, recomputed in the test |
| `testExtrospectRuntimeCodehash` | `keccak(type(Extrospect).runtimeCode) == pin` |

Nothing ran the pinned creation bytecode. The address came from a hand-written CREATE2 expression rather than the factory, and the codehash came from the compiler's `runtimeCode` metadata rather than from what a deploy leaves on chain — which is the thing `LibRainDeploy` verifies against post-broadcast. `testExtrospectDeployRecordReproduces` closes that loop by execution.

Deterministic and offline: `LibRainDeploy.etchZoltuFactory` etches the factory from its own pinned bytecode. No RPC, no skip.

Verdicts unchanged: no constant moves, no source under `src/lib/` is touched, nothing the library concludes about any contract changes.

## Adversarial mutation pass

Harness: `nix develop -c forge test --no-match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'`.

- That file is excluded because it needs `ARBITRUM_RPC_URL`, which is absent here; excluding it drops its 7 tests outright (https://github.com/rainlanguage/rain.extrospection/issues/85).
- `ExtrospectConstantsTest` is deliberately **not** excluded — it is the subject of this PR. Excluding it would report KILLED for every mutant and measure nothing.
- Baseline on this branch: **308 passed / 0 failed / 0 skipped**. On main, same command: **307 passed / 0 failed / 0 skipped**.

| # | mutant | where | tests that failed | verdict |
|---|---|---|---|---|
| M1 | `EXTROSPECT_ZOLTU_ADDRESS_V1` → `address(0x…01)` | `src/concrete/Extrospect.sol` | `testExtrospectZoltuAddress`, **`testExtrospectDeployRecordReproduces`** | killed (306/2) |
| M2 | `EXTROSPECT_RUNTIME_CODEHASH_V1` final nibble `f`→`e` | `src/concrete/Extrospect.sol` | `testExtrospectRuntimeCodehash`, **`testExtrospectDeployRecordReproduces`** | killed (306/2) |
| M3 | `EXTROSPECT_CREATION_BYTECODE_V1` final byte `56`→`57` (JUMP→JUMPI, still deploys) | `src/concrete/Extrospect.sol` | `testExtrospectCreationBytecode`, `testExtrospectZoltuAddress`, **`testExtrospectDeployRecordReproduces`** | killed (305/3) |
| M4 | `Extrospect.isEOFBytecode` returns the negation | `src/concrete/Extrospect.sol` | 3 `isEOFBytecode` equivalence tests, `testExtrospectCreationBytecode`, `testExtrospectRuntimeCodehash`, **`testExtrospectDeployRecordReproduces`** | killed (302/6) |
| M5 | Zoltu factory `CREATE2`→`CREATE` (`…8234f5…` → `…8234f0…` in `ZOLTU_FACTORY_BYTECODE`) | `dependencies/rain-deploy-0.1.3/src/lib/LibRainDeploy.sol` | **`testExtrospectDeployRecordReproduces` only** | killed (307/1) — **sole killer** |

5 mutants, 5 killed, 0 survived.

M5 is the discriminating one and the reason this test earns its place. The deployment *mechanism* is not expressible as an in-repo edit, and all three pre-existing constants tests survive it — a factory that stopped using CREATE2 would move the address on every chain, and only this test sees it. That surface goes live on any `rain-deploy` bump.

Working tree restored after the pass and re-run: **308 passed / 0 failed / 0 skipped**.

`nix develop -c forge fmt --check` clean.

## Why #44 stays open

Its prescribed `LibSnapshot` is gone, and its replacement is unpublished:

- `rain-sol-codegen`'s `LibSnapshot` was **deleted on 2026-08-13** (`49ffe9f`, "remove dead LibSnapshot") — it exists only in published 0.1.1–0.1.4 of 36 versions; HEAD is 0.1.36.
- The successor, `LibRainDeploySnapshot`, lives on `rain.deploy` **main only**. Latest published `rain-deploy` is 0.1.5 (2026-07-30) and does not contain it; this repo pins 0.1.3.
- `rain.deploy` has not itself cut a frozen `src/generated/<tag>/` under the new canon — only `candidate/`.
- The shape consumers are meant to inherit (`BuildScript` with a separate `cutRelease()`) is rainlanguage/rain.deploy#132, open.
- This repo publishes via `rainix-autopublish` on every push to main, which is exactly the lifecycle rainlanguage/rainix#273 is open about: a `<tag>/` keyed to `[package].version` opens an empty slot on the next auto-bump, main goes red, and no workflow run reports it.

Hand-rolling the freeze is what #44 itself forbids. The option space is on the issue.

## QA
- Discriminating tests: `testExtrospectDeployRecordReproduces` — sole killer of M5 (Zoltu factory `CREATE2`→`CREATE`), which all three pre-existing constants tests survive (307 passed / 1 failed); it does not exist on base, and the mechanism M5 breaks is unreachable from any base test.
- Mutations applied: `src/concrete/Extrospect.sol` address literal → `address(0x…01)` → `testExtrospectZoltuAddress` + new test; codehash literal final nibble `f`→`e` → `testExtrospectRuntimeCodehash` + new test; creation bytecode final byte `56`→`57` → `testExtrospectCreationBytecode` + `testExtrospectZoltuAddress` + new test; `isEOFBytecode` return negated → 3 equivalence tests + `testExtrospectCreationBytecode` + `testExtrospectRuntimeCodehash` + new test; `dependencies/rain-deploy-0.1.3/src/lib/LibRainDeploy.sol` `ZOLTU_FACTORY_BYTECODE` `…8234f5…`→`…8234f0…` → new test ONLY. 5 applied, 5 killed, 0 survived.
- Oracle: the EVM itself. The Zoltu factory is etched from `LibRainDeploy.ZOLTU_FACTORY_BYTECODE` and the pinned creation bytecode is executed through it; expected values are the three constants already committed under `src/concrete/Extrospect.sol`, none of which this diff touches. Independent of `type(Extrospect).creationCode` / `.runtimeCode`, which every pre-existing test reads instead.
- Category check: #44 asks for (A) a check that the generated record reproduces the hardcoded literals, (B) a generated per-release record under `src/generated/<tag>/`, (C) the hardcoded constants generated-and-aliased. Covered: A. Not covered: B, C — blocked on `LibRainDeploySnapshot` being unpublished, per the option space posted on the issue. This PR is `Part of`, not `Closes`.
