### PR TITLE
docs: isEOFBytecode NatSpec states the two-byte magic test it actually performs

### DIFF
--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -15,7 +15,7 @@ library LibExtrospectBytecode {
     /// Thrown when bytecode metadata is not trimmed as expected.
     error MetadataNotTrimmed();
 
-    /// Thrown when processing an EOF formatted bytecode.
+    /// Thrown when `isEOFBytecode` reports the bytecode as EOF.
     error EOFBytecodeNotSupported();
 
     /// Thrown when the bytecode hash does not match the expected value.
@@ -28,9 +28,15 @@ library LibExtrospectBytecode {
     /// compile without CBOR metadata entirely.
     error UnexpectedMetadata();
 
-    /// Returns whether the bytecode is in EOF format.
+    /// Returns whether the first two bytes of the bytecode are the EOF magic
+    /// `0xEF00`. The version byte that follows the magic in an EIP-3540
+    /// container is not read, so `0xEF00` alone and `0xEF00` followed by any
+    /// version byte are both reported as EOF. Bytecode shorter than two bytes
+    /// is not reported as EOF, and neither is bytecode starting with `0xEF`
+    /// followed by any byte other than `0x00`, including the `0xEF01` of an
+    /// EIP-7702 delegation designator.
     /// @param bytecode The bytecode to check.
-    /// @return isEOF Whether the bytecode is in EOF format.
+    /// @return isEOF Whether the first two bytes are `0xEF00`.
     function isEOFBytecode(bytes memory bytecode) internal pure returns (bool isEOF) {
         if (bytecode.length >= 2) {
             assembly ("memory-safe") {
@@ -40,7 +46,8 @@ library LibExtrospectBytecode {
         }
     }
 
-    /// Checks that the bytecode is not in EOF format. Reverts if it is.
+    /// Reverts with `EOFBytecodeNotSupported` if `isEOFBytecode` returns true
+    /// for the bytecode.
     /// @param bytecode The bytecode to check.
     //forge-lint: disable-next-line(mixed-case-function)
     function checkNotEOFBytecode(bytes memory bytecode) internal pure {


### PR DESCRIPTION
Part of https://github.com/rainlanguage/rain.extrospection/issues/53

**This PR does not close #53.** It lands only the part of that issue that
changes no verdict. The classification question — whether `0xEF00` without a
version byte is EOF, and whether an `0xEF01` EIP-7702 delegation designator
should be — changes what the library concludes about real accounts, so it is
posted as an option space on the issue and left for a human ruling.

## What changed

NatSpec on `isEOFBytecode`, `checkNotEOFBytecode` and the
`EOFBytecodeNotSupported` error in `src/lib/LibExtrospectBytecode.sol`.

The doc said `isEOFBytecode` "Returns whether the bytecode is in EOF format".
It does not. It reads exactly two bytes and compares them to `0xEF00`, which
means:

- `0xEF00` with **no** version byte, and `0xEF00` followed by **any** version
  byte including invalid ones, are all reported as EOF;
- `0xEF` followed by anything other than `0x00` is **not** reported as EOF,
  which includes the 23-byte `0xef0100 || address` EIP-7702 delegation
  designator, the only `0xEF`-prefixed account code that exists today;
- bytecode shorter than two bytes is not reported as EOF.

The NatSpec now states that. Zero behaviour change: no source statement was
touched, only comments.

## Claims verified before writing anything

All five rows reproduce at `32f7325`:

| Input | `isEOFBytecode` | `checkNotEOFBytecode` |
| --- | --- | --- |
| `hex"EF00"` | `true` | reverts `EOFBytecodeNotSupported` |
| `hex"EF0000"` | `true` | reverts `EOFBytecodeNotSupported` |
| `hex"EF0001010004"` (real EOFv1 container) | `true` | reverts `EOFBytecodeNotSupported` |
| `abi.encodePacked(hex"ef0100", address)` (23 bytes) | `false` | passes, goes to the linear scanner |
| `hex"ef"` | `false` | passes |

## Test baseline

```
nix develop -c forge test \
  --no-match-contract ExtrospectConstantsTest \
  --no-match-test 'testCheckCBORTrimmedBytecodeHash(Failure|MetadataNotTrimmed|Success)'
```

**308 passed / 0 failed / 0 skipped**, 26 suites — identical before and after
this diff.

Exclusions and what they cost:

- `ExtrospectConstantsTest` (3 tests) pins the deployed creation bytecode,
  CREATE2 address and runtime codehash, so it fails under *every* source
  mutation and would report `KILLED` for every mutant while measuring nothing.
  Excluded from the mutation matrix; it passes on the unmutated baseline.
- The three `checkCBORTrimmedBytecodeHash` fork tests (`...Failure`,
  `...MetadataNotTrimmed`, `...Success`) need `ARBITRUM_RPC_URL`, which is not
  available here. Excluded **by test name, not by file**, so the four non-fork
  tests in that file — including `testCheckCBORTrimmedBytecodeHashEOF`, which
  is directly on this PR's subject — stay in the matrix. Excluding the whole
  file would have dropped all seven, which is #85.

Unfiltered whole suite is 311 passed / 3 failed, the 3 being those fork tests.

## Adversarial mutation pass

Every mutant below was applied to `src/lib/LibExtrospectBytecode.sol` one at a
time, with `git diff` captured to prove the source really changed, then the
whole 308-test suite run. "Suite ran" is the `Ran N test suites ... (308 total
tests)` line from that mutant's own run, so a mutant that failed to compile or
matched nothing cannot masquerade as `SURVIVED`.

| # | Mutation in `src/lib/LibExtrospectBytecode.sol` | Suite ran | Result | Killed by |
| --- | --- | --- | --- | --- |
| M01 | `if (bytecode.length >= 2)` → `>= 1` | 308 tests | **KILLED** (3 failed) | `testIsEOFBytecodeSingleByte`, `testIsEOFBytecodeFuzz`, `testCheckNotMetamorphicFuzz` |
| M02 | `if (bytecode.length >= 2)` → `>= 3` | 308 tests | **KILLED** (5 failed) | `testIsEOFBytecodeExactTwoBytes` |
| M03 | mask `0xFFFF` → `0xFF` (compare only the second byte) | 308 tests | **KILLED** (13 failed) | `testIsEOFBytecodeEOF`, `testCheckCBORTrimmedBytecodeHashEOF` |
| M04 | magic `0xEF00` → `0xEF01` | 308 tests | **KILLED** (13 failed) | `testIsEOFBytecodeEOF`, `testCheckNotEOFBytecodeRevertsOnEOF` |
| M05 | magic `0xEF00` → `0xEF` (i.e. `0x00EF`) | 308 tests | **KILLED** (13 failed) | `testIsEOFBytecodeEOF`, `testCheckNoMetadataEOF` |
| M06 | `eq(firstTwoBytes, 0xEF00)` → `lt(...)` | 308 tests | **KILLED** (199 failed) | `testCheckCBORTrimmedBytecodeHashEquivalencePass` + 30 more |
| M07 | read offset `add(bytecode, 2)` → `add(bytecode, 3)` (reads bytes 1–2, not 0–1) | 308 tests | **KILLED** (13 failed) | `testIsEOFBytecodeEOF`, `testCheckNotMetamorphicRevertsOnEOF` |
| M08 | `if (isEOFBytecode(bytecode))` → `if (!isEOFBytecode(bytecode))` | 308 tests | **KILLED** (216 failed) | `testCheckCBORTrimmedBytecodeHashEmptyAccount` + 40 more |
| M09 | `revert EOFBytecodeNotSupported();` → `return;` | 308 tests | **KILLED** (9 failed) | all nine `...RevertsOnEOF` / `...EOF` tests |
| M10 | drop the `checkNotEOFBytecode` gate from `tryTrimSolidityCBORMetadata` | 308 tests | **KILLED** (3 failed) | `testTryTrimSolidityCBORMetadataRevertsOnEOF`, `testCheckCBORTrimmedBytecodeHashEOF`, `testCheckNoMetadataEOF` |
| M11 | drop the gate from `scanEVMOpcodesReachableInBytecode` | 308 tests | **KILLED** (3 failed) | `testScanEVMOpcodesReachableRevertsOnEOF`, `testScanMetamorphicRiskRevertsOnEOF`, `testCheckNotMetamorphicRevertsOnEOF` |
| M12 | drop the gate from `scanEVMOpcodesPresentInBytecode` | 308 tests | **KILLED** (1 failed) | `testScanEVMOpcodesPresentRevertsOnEOF` |

**12 applied, 12 killed, 0 survived.** Every row's "Suite ran" is that mutant's
own `(308 total tests)` line, and every row has a captured `git diff` showing
the source really changed — a mutant that silently failed to apply, or a
filter that matched nothing, could not have produced these.

Two things the matrix shows that are worth keeping:

- M12 is killed by exactly **one** test. `testScanEVMOpcodesPresentRevertsOnEOF`
  is the only thing standing between `scanEVMOpcodesPresentInBytecode` and an
  ungated linear scan of EOF bytes.
- `testCheckCBORTrimmedBytecodeHashEOF` kills M03, M04, M05, M07, M09 and M10.
  It lives in the file whose fork tests need `ARBITRUM_RPC_URL`, so excluding
  that file wholesale — rather than the three fork tests by name — would have
  removed a killer for half the matrix. That is the concrete cost #85 describes.

## QA

- **Discriminating tests:** n/a — comment-only diff, no statement changed, so
  there is no behaviour a new test could discriminate. The standing ruling
  forbids tests that assert prose, so the NatSpec is deliberately not
  test-covered. The suite is byte-identical before and after at 308 / 0.
- **Mutations applied:** 12, table above, all killed, each with its killing
  test. Every gate call site (`tryTrim…`, `scanEVMOpcodesReachable…`,
  `scanEVMOpcodesPresent…`) mutated independently, plus the length guard, the
  read offset, the mask, the magic constant, the comparison operator and the
  revert.
- **Oracle:** EIP-3540 (EOF container is `0xEF00` magic **followed by** a
  version byte), EIP-3541 (`0xEF` is a reserved prefix), EIP-7702 (delegation
  designator is `0xef0100 || address`, 23 bytes), and the executable behaviour
  of the assembly itself observed at `32f7325`. The new NatSpec was written
  from what the assembly computes, not from the sentence it replaced.
- **Category check:** #53 raises four things — (a) `0xEF00` with no version
  byte is classified EOF and reverts, (b) `0xEF01` 7702 designators are not
  classified EOF and fall through, (c) 1-byte `0xEF` is not classified EOF,
  (d) nothing in NatSpec states any of the above. **Covered: (d) only.**
  (a), (b) and (c) each change what the library concludes about real accounts —
  what reverts, what passes, and therefore what `checkNotMetamorphic` answers.
  Those are posted as a four-option decision on the issue and left for a human
  ruling, which is why this is `Part of` and not `Closes`.
