### PR TITLE
Describe how the reachable scan treats data regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ in other EVM language compilers.
 The "reachable in" scan understands enough about the EVM execution environment to
 ignore data that is not reachable by a `JUMPDEST`. This is achieved by pausing
 the scanner after any opcode that halts execution, then resuming it once a jump
-destination is found. This scan DOES NOT cause false positives due to metdata or
-similar "data only" regions of a contract, however it is susceptible to breakages
+destination is found. A "data only" region such as the CBOR metadata is skipped
+only for as long as the scanner stays paused. A `0x5b` byte that the linear sweep
+lands on inside such a region resumes the scan, and every opcode after it in that
+region is reported as reachable. The scanner is susceptible to breakages
 if the EVM execution model ever changes. For example, if the set of halting ops
 ever changes, or a new `JUMPDEST` alternative is invented, the scanner will
 require an entirely new implementation and redeployment to support this.

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -160,6 +160,10 @@ library LibExtrospectBytecode {
     /// a halt and the next JUMPDEST are treated as unreachable and excluded.
     /// This is an over-approximation because not all JUMPDESTs are actually
     /// reachable at runtime.
+    /// The sweep does not distinguish code from data, so a JUMPDEST byte that it
+    /// lands on inside a data region such as Solidity CBOR metadata resumes
+    /// scanning, and the opcodes after it in that region are reported as
+    /// reachable.
     /// Adapted from https://github.com/MrLuit/selfdestruct-detect/blob/master/src/index.ts
     /// NOTE: Reverts with `EOFBytecodeNotSupported` if the bytecode is EOF
     /// (EIP-7692).


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/58

**Partial — do not merge without ruling first.** `Closes` will auto-close #58, but
this PR lands only the part that changes no verdict. Rule A/B/C/D on the issue
first, or reopen #58 after merge. The part
that does change a verdict — which of the two trim/scan compositions the library
owns — is posted as an option space on the issue and is deliberately not
implemented here.

## The claim, verified

All four repros reproduce at `32f7325` (current `main`), via a throwaway
`test/triage/Triage58.t.sol` that is **not** part of this diff:

| repro | result |
| --- | --- |
| `scanMetamorphicRisk(hex"005bff") == 1 << 0xFF` and `scanMetamorphicRisk(hex"005cff") == 0` | confirmed |
| a bare-`STOP` body is flagged metamorphic purely by its canonical trailer bytes | confirmed |
| trim-then-scan drops the risk the untrimmed scan reports | confirmed |
| the repo's own `METAMORPHIC_METADATA` fixture scans clean after a trim | confirmed |

## What this changes

Documentation only. No compiled byte changes; no verdict this library reaches
changes.

The README claimed:

> This scan DOES NOT cause false positives due to metdata or similar "data only"
> regions of a contract

That is not what the reachable scan does. The scan pauses at a halting opcode and
resumes at the first `0x5b` byte the linear sweep lands on, wherever that byte
sits — including inside a CBOR metadata trailer. The repo's own
`METAMORPHIC_METADATA` fixture is a contract whose only reachable `SELFDESTRUCT`
is in its trailer, and the suite asserts the scan finds it, so the README sentence
and the test suite could not both be right.

README and the NatSpec on `scanEVMOpcodesReachableInBytecode` now describe the
sweep's actual treatment of data regions.

## What this deliberately does not change

- No change to `scanMetamorphicRisk`, `checkNotMetamorphic`, or the scan itself.
- No new composite entry point on `IExtrospectV1`.
- No test added that pins either composition — that would entrench the design the
  issue asks a human to rule on.

The README's stale interface surface (`IExtrospectBytecodeV2`,
`scanEVMOpcodesPresentInAccount`, …) is left alone: that is issue #88. The local
nix `pre-commit` hook wants to reflow the whole README, which CI
(`rainix-sol-static`: slither, `forge fmt --check`, single-contract) does not
enforce; that reflow is not in this diff.

## Verification

Toolchain is nix throughout (`nix develop -c forge test`, `nix develop -c forge fmt`).

- Full suite on a fresh clone: **311 passed / 3 failed**. The 3 are inside
  `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol`, which
  needs `ARBITRUM_RPC_URL` (absent here) — issue #85.
- `nix develop -c forge fmt --check` clean.

## Adversarial mutation pass

Both exclusions this repo's harness requires are applied, and stated:

- `test/src/concrete/Extrospect.constants.t.sol` — `ExtrospectConstantsTest` pins
  deployed bytecode, so it fails under every source mutation and would report
  KILLED for every mutant while measuring nothing (issue #84).
- `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` — needs
  `ARBITRUM_RPC_URL`. Excluding it loses all 7 of its tests (issue #85); 3 of
  those fail here for want of the RPC and 4 pass, so 4 real tests are given up.

Baseline with both exclusions: **304 passed / 0 failed**, 25 suites.

Mutants target `scanEVMOpcodesReachableInBytecode` — the function whose behaviour
this PR now documents — to prove the newly written sentence is pinned by tests
rather than merely asserted by prose.

| # | mutation | tests ran | result | killed by | verdict |
| --- | --- | --- | --- | --- | --- |
| M1 | resume the sweep on `0x5C` instead of `opJumpDest` | 304 | 223 passed / 81 failed | `testCheckNotMetamorphicRevertsOnMetamorphicMetadata`, `testScanEVMOpcodesReachableReference` | KILLED |
| M2 | drop `halted := 0` — the sweep never resumes | 304 | 223 passed / 81 failed | same 81 | KILLED |
| M3 | drop `halted := 1` — the sweep never pauses | 304 | 291 passed / 13 failed | `testScanEVMOpcodesReachableStop`, `testScanMetamorphicMetadata` | KILLED |
| M4 | drop the `JUMPDEST` bit when resuming | 304 | 302 passed / 2 failed | `testScanEVMOpcodesReachableJumpdest`, `testScanEVMOpcodesReachableReference` | KILLED |
| M5 | skip `PUSH*` inline data only while not halted | 304 | 301 passed / 3 failed | `testScanEVMOpcodesReachablePushWhileHalted`, `testScanMetamorphicRiskReference` | KILLED |

5 mutants, 5 killed, 0 survived. Every run reports `304 total tests` against a
`304 total tests` baseline, so no mutant was scored against a filter that matched
nothing and no run was a silently-empty suite.

## QA

- **Discriminating tests:** n/a — the diff is a README sentence and a NatSpec
  block, so no test can distinguish base from head. What was verified instead: the
  four issue repros were run against **base** at `32f7325` in a throwaway
  `test/triage/Triage58.t.sol` and all four pass there, i.e. the documented
  behaviour is the behaviour base actually has. Per the standing ruling, no test
  in this diff reads or asserts prose.
- **Mutations applied:** 5 on `src/lib/LibExtrospectBytecode.sol`
  `scanEVMOpcodesReachableInBytecode`, all killed —
  `if eq(op, opJumpDest)` → `if eq(op, 0x5C)` → killed by
  `testCheckNotMetamorphicRevertsOnMetamorphicMetadata`;
  `halted := 0` deleted → killed by `testCheckNotMetamorphicRevertsOnSelfdestruct`;
  `halted := 1` deleted → killed by `testScanEVMOpcodesReachableStop`;
  `bytesReachable := or(...)` deleted from the resume branch → killed by
  `testScanEVMOpcodesReachableJumpdest`;
  `PUSH*` skip moved inside `case 0` → killed by
  `testScanEVMOpcodesReachablePushWhileHalted`.
  Full run logs and per-mutant diffs at
  `/home/gildlab/artifacts/2026-08-18-extro-issues/i-58/mut-*.{log,diff}`.
- **Oracle:** the repo's own `METAMORPHIC_METADATA` fixture (from
  `rainprotocol/metamorphic-metadata`), whose only reachable `SELFDESTRUCT` lives
  in its CBOR trailer — an authority independent of both the README sentence and
  the scan implementation. It, and the README, cannot both be right; the fixture
  and the deployed behaviour agree, so the README was the wrong one.
- **Category check:** the issue raises four things — (a) the README false-positive
  claim, (b) scan-without-trim deciding a verdict on metadata bytes, (c)
  trim-then-scan erasing real risk, (d) `IExtrospectV1` exposing no composite.
  Covered here: (a). Not covered here by design: (b), (c), (d) each change what
  the library concludes about some contract, so they are surfaced as an option
  space on the issue for a human ruling rather than decided in a PR.
