### PR TITLE
Document the codeless-account verdict on both account-taking CBOR checks

### DIFF
--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -123,6 +123,10 @@ library LibExtrospectBytecode {
     /// Checks that the bytecode of an account, after trimming Solidity CBOR
     /// metadata, matches an expected hash. Reverts if the metadata was not
     /// trimmed or if the hash does not match after trimming.
+    /// An account with no code — an externally owned account, an unoccupied
+    /// `CREATE2` target, or a self-destructed account — reads as empty
+    /// bytecode, which is too short to carry metadata, so it reverts
+    /// `MetadataNotTrimmed` before any hash is compared.
     /// @param account The account whose bytecode to check.
     /// @param expected The expected hash of the trimmed bytecode.
     function checkCBORTrimmedBytecodeHash(address account, bytes32 expected) internal view {
@@ -142,6 +146,12 @@ library LibExtrospectBytecode {
     /// inverse of `checkCBORTrimmedBytecodeHash` — use this when bytecode
     /// should have been compiled without metadata (e.g. `cbor_metadata = false`
     /// in foundry.toml) as a defense against the metamorphic metadata attack.
+    /// An account with no code — an externally owned account, an unoccupied
+    /// `CREATE2` target, or a self-destructed account — reads as empty
+    /// bytecode, which carries no metadata, so it passes on the same terms as
+    /// an account whose code was compiled without metadata. Whether the account
+    /// has any code at all is not checked here, so the two account-taking
+    /// checks answer a codeless account in opposite directions.
     /// @param account The account whose bytecode to check.
     //forge-lint: disable-next-line(mixed-case-function)
     function checkNoSolidityCBORMetadata(address account) internal view {

--- a/test/src/concrete/Extrospect.checkNoSolidityCBORMetadata.t.sol
+++ b/test/src/concrete/Extrospect.checkNoSolidityCBORMetadata.t.sol
@@ -14,8 +14,10 @@ contract ExtrospectCheckNoSolidityCBORMetadataTest is ExtrospectEquivalence {
 
     function testCheckNoSolidityCBORMetadataEquivalencePass() external view {
         // Account with no code passes both.
-        extrospect.checkNoSolidityCBORMetadata(address(0xdead));
-        LibExtrospectBytecode.checkNoSolidityCBORMetadata(address(0xdead));
+        address codeless = address(0xdead);
+        assertEq(codeless.code.length, 0);
+        extrospect.checkNoSolidityCBORMetadata(codeless);
+        LibExtrospectBytecode.checkNoSolidityCBORMetadata(codeless);
     }
 
     function testCheckNoSolidityCBORMetadataEquivalenceRevert() external {

--- a/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
@@ -40,8 +40,10 @@ contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
     /// Test that an empty account (no deployed code) reverts with
     /// MetadataNotTrimmed since there is no metadata to trim.
     function testCheckCBORTrimmedBytecodeHashEmptyAccount() external {
+        address codeless = address(0xdead);
+        assertEq(codeless.code.length, 0);
         vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.MetadataNotTrimmed.selector));
-        this.externalCheckCBORTrimmedBytecodeHash(address(0xdead), bytes32(0));
+        this.externalCheckCBORTrimmedBytecodeHash(codeless, bytes32(0));
     }
 
     function testCheckCBORTrimmedBytecodeHashMetadataNotTrimmed() external {

--- a/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
@@ -16,7 +16,9 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
 
     /// Account with no code passes (no metadata to detect).
     function testCheckNoMetadataEmptyAccount() external view {
-        LibExtrospectBytecode.checkNoSolidityCBORMetadata(address(0xdead));
+        address codeless = address(0xdead);
+        assertEq(codeless.code.length, 0);
+        LibExtrospectBytecode.checkNoSolidityCBORMetadata(codeless);
     }
 
     /// Contract compiled without metadata passes. This project compiles with


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/61

**This PR is the half of #61 that changes no verdict.** The verdict question the issue actually asks — should an absence check reject an account with no code — is posted as an option space on the issue and is not decided here. Every input that passed before passes now, with identical returndata.

## What the issue reports, verified against `main` @ `32f7325`

`checkNoSolidityCBORMetadata` answers "no metadata" for an address with no code, while `checkCBORTrimmedBytecodeHash` reverts `MetadataNotTrimmed` for the same address. Both reproduce. Neither NatSpec said so.

The divergence is not two decisions pointing opposite ways — it is one boolean read two ways. `tryTrimSolidityCBORMetadata` needs `length >= 53`, so empty bytecode yields `didTrim == false`. The presence check wants that `true` and reverts without it; the absence check wants it `false` and passes on it.

## What this PR changes

- NatSpec on both account-taking checks now states what each concludes about an account with no code, naming the population: an externally owned account, an unoccupied `CREATE2` target, a self-destructed account.
- The three tests that pin that verdict now assert `code.length == 0` as an explicit precondition instead of trusting `address(0xdead)` to stay empty.

`src/` changes are comments only. `ExtrospectConstantsTest` passes unchanged, so `EXTROSPECT_CREATION_BYTECODE_V1`, `EXTROSPECT_ZOLTU_ADDRESS_V1` and `EXTROSPECT_RUNTIME_CODEHASH_V1` are untouched and the deployed `Extrospect` is unaffected.

## Tests ran

Baseline on `main` before any change, excluding `ExtrospectConstantsTest` and the fork-gated `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol`:

```
Ran 25 test suites in 1.37s (13.58s CPU time): 304 tests passed, 0 failed, 0 skipped (304 total tests)
```

On this branch, excluding only the fork-gated file — this run **includes** `ExtrospectConstantsTest`, which is what proves the deployed bytecode is byte-identical:

```
Ran 26 test suites in 1.09s (10.98s CPU time): 307 tests passed, 0 failed, 0 skipped (307 total tests)
```

The four tests in the fork-gated file that do not need `ARBITRUM_RPC_URL`, run separately, including the one this PR touches:

```
[PASS] testCheckCBORTrimmedBytecodeHashEOF() (gas: 4616)
[PASS] testCheckCBORTrimmedBytecodeHashEmptyAccount() (gas: 7183)
[PASS] testCheckCBORTrimmedBytecodeHashFuzz(bytes,bytes32) (runs: 2048, μ: 8419, ~: 8391)
[PASS] testCheckCBORTrimmedBytecodeHashNoMetadataFuzz(bytes,bytes32) (runs: 2048, μ: 6998, ~: 6881)
Suite result: ok. 4 passed; 0 failed; 0 skipped
```

The other three in that file need `ARBITRUM_RPC_URL`, absent in this environment — #85.

## Adversarial mutation pass

The only executable content in this diff is the three new `code.length == 0` preconditions, so that is what the mutants target. The hazard each one guards is fixture drift: the fixture address silently stops being codeless, the test stays green, and the codeless verdict stops being tested at all. Mutant: point the fixture at `new NonMetamorphic()` — 116 bytes of code, no CBOR metadata, so the function under test still returns exactly what the test's outer assertion expects.

| # | mutant | file | this branch | `main`'s test body |
| --- | --- | --- | --- | --- |
| M1 | `testCheckNoMetadataEmptyAccount` fixture → `new NonMetamorphic()` | `test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol` | **KILLED** — `assertion failed: 116 != 0` | **SURVIVED** — `[PASS] (gas: 56374)` |
| M2 | `testCheckNoSolidityCBORMetadataEquivalencePass` fixture → `new NonMetamorphic()` | `test/src/concrete/Extrospect.checkNoSolidityCBORMetadata.t.sol` | **KILLED** — `assertion failed: 116 != 0` | **SURVIVED** — `[PASS] (gas: 62419)` |
| M3 | `testCheckCBORTrimmedBytecodeHashEmptyAccount` fixture → `new NonMetamorphic()` | `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` | **KILLED** — `assertion failed: 116 != 0` | **SURVIVED** — `[PASS] (gas: 60165)` |

Killed run:

```
[FAIL: assertion failed: 116 != 0] testCheckNoSolidityCBORMetadataEquivalencePass() (gas: 58655)
[FAIL: assertion failed: 116 != 0] testCheckCBORTrimmedBytecodeHashEmptyAccount() (gas: 58656)
[FAIL: assertion failed: 116 != 0] testCheckNoMetadataEmptyAccount() (gas: 58656)
Ran 3 test suites in 6.90ms (902.60µs CPU time): 0 tests passed, 3 failed, 0 skipped (3 total tests)
```

Survived run, same mutants with the preconditions removed — i.e. `main`'s bodies:

```
[PASS] testCheckNoMetadataEmptyAccount() (gas: 56374)
[PASS] testCheckCBORTrimmedBytecodeHashEmptyAccount() (gas: 60165)
[PASS] testCheckNoSolidityCBORMetadataEquivalencePass() (gas: 62419)
Ran 3 test suites in 6.88ms (840.99µs CPU time): 3 tests passed, 0 failed, 0 skipped (3 total tests)
```

`ExtrospectConstantsTest` was excluded from every mutation run. It pins deployed bytecode, so it fails under any source mutation and would report KILLED for every mutant while measuring nothing.

### Mutants not run

Source-side mutants of `checkNoSolidityCBORMetadata`, `checkCBORTrimmedBytecodeHash` and `tryTrimSolidityCBORMetadata` were attempted and could not be applied — this environment's harness blocks behaviour-changing edits to `src/` in this repo. They are listed here rather than reported as results:

- `checkNoSolidityCBORMetadata` reverts when `bytecode.length == 0`
- `checkNoSolidityCBORMetadata` inverts its `didTrim` guard
- `checkCBORTrimmedBytecodeHash` skips its `!didTrim` revert
- `tryTrimSolidityCBORMetadata` length guard `>= 53` → `>= 52`

None of them bear on this diff, whose src change is comments.

## QA
- Discriminating tests: `testCheckNoMetadataEmptyAccount`, `testCheckNoSolidityCBORMetadataEquivalencePass`, `testCheckCBORTrimmedBytecodeHashEmptyAccount` — each fails on base (ran the identical fixture mutant against `main`'s bodies: all three `[PASS]`, i.e. survived; against this branch's bodies: all three `[FAIL: assertion failed: 116 != 0]`, i.e. killed — full output in the mutation section above)
- Mutations applied: `test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol:19` `address(0xdead)` → `address(new NonMetamorphic())` → killed by `testCheckNoMetadataEmptyAccount`; `test/src/concrete/Extrospect.checkNoSolidityCBORMetadata.t.sol:17` same mutation → killed by `testCheckNoSolidityCBORMetadataEquivalencePass`; `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol:43` same mutation → killed by `testCheckCBORTrimmedBytecodeHashEmptyAccount`. Source-side mutants of `checkNoSolidityCBORMetadata` / `checkCBORTrimmedBytecodeHash` / `tryTrimSolidityCBORMetadata` could not be applied — the harness blocks behaviour-changing edits to `src/` here; enumerated unrun under "Mutants not run", and none bear on this diff, whose `src/` change is comments
- Oracle: the EVM account state, not the library. `codeless.code.length` is read from the account and the expected `0` is what "an address with no deployed code" means by definition, so the library's own opinion never enters the assertion. The NatSpec sentences were derived independently by reading `tryTrimSolidityCBORMetadata`'s `length >= 53` guard and tracing `didTrim == false` into each caller, then confirmed against executed repros at `32f7325`
- Category check: issue asks (a) state what each account-taking check concludes about a codeless account, (b) rule whether an empty account should revert; covered (a), at BOTH `checkNoSolidityCBORMetadata` and `checkCBORTrimmedBytecodeHash` rather than only the reported one, because the property is "an account-taking check's codeless answer is undocumented" and both instances have it. (b) is deliberately NOT covered: it changes a verdict, so it is posted as an option space on the issue for a human ruling and this PR must not be read as answering it
