### PR TITLE
refactor: name the Solidity CBOR metadata constants

### DIFF
--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -15,11 +15,12 @@ uint256 constant SOLIDITY_CBOR_METADATA_LENGTH = 53;
 
 /// @dev Mask for the first of the two overlapping 32-byte words that cover the
 /// final `SOLIDITY_CBOR_METADATA_LENGTH` bytes of bytecode. That word holds the
-/// 11 bytes of bytecode preceding the metadata followed by metadata bytes 0-20.
-/// The mask keeps metadata bytes 0-7 (`a2` map header, `64` text header,
-/// `69706673` as `ipfs`, `5822` byte string header) and zeros both the 11
-/// preceding bytecode bytes and metadata bytes 8-20, which are the first 13
-/// bytes of the 34-byte IPFS hash.
+/// 11 bytes preceding the metadata in memory, which are bytecode unless the
+/// bytecode is shorter than 64 bytes, followed by metadata bytes 0-20. The mask
+/// keeps metadata bytes 0-7 (`a2` map header, `64` text header, `69706673` as
+/// `ipfs`, `5822` byte string header) and zeros both those 11 preceding bytes
+/// and metadata bytes 8-20, which are the first 13 bytes of the 34-byte IPFS
+/// hash.
 //slither-disable-next-line too-many-digits
 uint256 constant SOLIDITY_CBOR_METADATA_HEAD_MASK = 0xFFFFFFFFFFFFFFFF00000000000000000000000000;
 

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -5,6 +5,42 @@ pragma solidity ^0.8.25;
 import {LibBytes, Pointer} from "rain-solmem-0.1.3/src/lib/LibBytes.sol";
 import {EVM_OP_JUMPDEST, HALTING_BITMAP} from "./EVMOpcodes.sol";
 
+/// @dev Byte length of the standard Solidity CBOR metadata trailer that
+/// `LibExtrospectBytecode.tryTrimSolidityCBORMetadata` matches and trims. The
+/// trailer is 51 bytes of CBOR body followed by 2 bytes that encode that body
+/// length, so every byte of it is accounted for by
+/// `SOLIDITY_CBOR_METADATA_HEAD_MASK` and `SOLIDITY_CBOR_METADATA_TAIL_MASK`
+/// together.
+uint256 constant SOLIDITY_CBOR_METADATA_LENGTH = 53;
+
+/// @dev Mask for the first of the two overlapping 32-byte words that cover the
+/// final `SOLIDITY_CBOR_METADATA_LENGTH` bytes of bytecode. That word holds the
+/// 11 bytes of bytecode preceding the metadata followed by metadata bytes 0-20.
+/// The mask keeps metadata bytes 0-7 (`a2` map header, `64` text header,
+/// `69706673` as `ipfs`, `5822` byte string header) and zeros both the 11
+/// preceding bytecode bytes and metadata bytes 8-20, which are the first 13
+/// bytes of the 34-byte IPFS hash.
+//slither-disable-next-line too-many-digits
+uint256 constant SOLIDITY_CBOR_METADATA_HEAD_MASK = 0xFFFFFFFFFFFFFFFF00000000000000000000000000;
+
+/// @dev Mask for the second of the two overlapping 32-byte words that cover the
+/// final `SOLIDITY_CBOR_METADATA_LENGTH` bytes of bytecode. That word holds
+/// metadata bytes 21-52. The mask keeps metadata bytes 42-47 (`64` text header,
+/// `736f6c63` as `solc`, `43` byte string header) and metadata bytes 51-52 (the
+/// 2-byte body length), and zeros metadata bytes 21-41, the last 21 bytes of the
+/// IPFS hash, along with metadata bytes 48-50, the 3-byte solc version.
+//slither-disable-next-line too-many-digits
+uint256 constant SOLIDITY_CBOR_METADATA_TAIL_MASK = 0x000000000000000000000000000000000000000000FFFFFFFFFFFF000000FFFF;
+
+/// @dev `keccak256` of `SOLIDITY_CBOR_METADATA_HEAD_MASK` applied to the first
+/// word concatenated with `SOLIDITY_CBOR_METADATA_TAIL_MASK` applied to the
+/// second, for bytecode whose final `SOLIDITY_CBOR_METADATA_LENGTH` bytes are
+/// standard Solidity CBOR metadata. Because the masks zero every variable byte,
+/// this single hash pins every structural byte the masks keep, including the
+/// `0033` body length that makes the trailer 53 bytes long.
+bytes32 constant SOLIDITY_CBOR_METADATA_MASKED_HASH =
+    0x0e55864b80a56accebaca64500e23598f6acfb743a5475323f0b7f2d0d268c62;
+
 /// @title LibExtrospectBytecode
 /// @notice Internal algorithms for extrospecting bytecode. Notably the EVM
 /// opcode scanning needs special care, as the other bytecode functions are mere
@@ -96,17 +132,17 @@ library LibExtrospectBytecode {
     function tryTrimSolidityCBORMetadata(bytes memory bytecode) internal pure returns (bool didTrim) {
         checkNotEOFBytecode(bytecode);
         uint256 length = bytecode.length;
-        if (length >= 53) {
-            // Two overlapping 32-byte reads cover the last 53 bytes of
-            // bytecode (the metadata). The masks zero out the variable parts
-            // (34-byte IPFS hash and 3-byte solc version), preserving only the
-            // fixed CBOR structure bytes: a2 64 "ipfs" 5822 ... 64 "solc" 43
-            // ... 0033. The expected hash is keccak256 of the masked result.
+        if (length >= SOLIDITY_CBOR_METADATA_LENGTH) {
+            // Two overlapping 32-byte reads cover the last
+            // `SOLIDITY_CBOR_METADATA_LENGTH` bytes of bytecode (the metadata).
+            // The masks zero out the variable parts, so the surviving
+            // structural bytes hash to `SOLIDITY_CBOR_METADATA_MASKED_HASH`
+            // exactly when the metadata matches.
             //slither-disable-next-line too-many-digits
-            uint256 maskA = 0xFFFFFFFFFFFFFFFF00000000000000000000000000;
+            uint256 maskA = SOLIDITY_CBOR_METADATA_HEAD_MASK;
             //slither-disable-next-line too-many-digits
-            uint256 maskB = 0x000000000000000000000000000000000000000000FFFFFFFFFFFF000000FFFF;
-            bytes32 expectedHash = bytes32(uint256(0x0e55864b80a56accebaca64500e23598f6acfb743a5475323f0b7f2d0d268c62));
+            uint256 maskB = SOLIDITY_CBOR_METADATA_TAIL_MASK;
+            bytes32 expectedHash = SOLIDITY_CBOR_METADATA_MASKED_HASH;
             bytes32 relevantHash;
             assembly ("memory-safe") {
                 // Point 0x20 bytes before the end of the bytecode.
@@ -115,7 +151,7 @@ library LibExtrospectBytecode {
                 mstore(0x20, and(maskB, mload(end)))
                 relevantHash := keccak256(0, 0x40)
                 didTrim := eq(relevantHash, expectedHash)
-                if didTrim { mstore(bytecode, sub(length, 53)) }
+                if didTrim { mstore(bytecode, sub(length, SOLIDITY_CBOR_METADATA_LENGTH)) }
             }
         }
     }

--- a/test/src/lib/LibExtrospectBytecode.constants.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.constants.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {
+    SOLIDITY_CBOR_METADATA_LENGTH,
+    SOLIDITY_CBOR_METADATA_HEAD_MASK,
+    SOLIDITY_CBOR_METADATA_TAIL_MASK,
+    SOLIDITY_CBOR_METADATA_MASKED_HASH
+} from "src/lib/LibExtrospectBytecode.sol";
+import {SOLIDITY_CBOR_RUNTIME_FIXTURE} from "test/concrete/SolidityCBORFixture.sol";
+
+/// @dev The two 32-byte words that the head and tail masks leave behind for
+/// bytecode ending in standard Solidity CBOR metadata. The head word is 11
+/// zeroed bytes of preceding bytecode, then metadata bytes 0-7
+/// `a2 64 69706673 5822`, then 13 zeroed bytes of IPFS hash.
+bytes32 constant EXPECTED_MASKED_HEAD_WORD = 0x0000000000000000000000a26469706673582200000000000000000000000000;
+
+/// @dev The tail word is the remaining 21 zeroed bytes of IPFS hash, then
+/// metadata bytes 42-47 `64 736f6c63 43`, then 3 zeroed bytes of solc version,
+/// then metadata bytes 51-52 `0033`.
+bytes32 constant EXPECTED_MASKED_TAIL_WORD = 0x00000000000000000000000000000000000000000064736f6c63430000000033;
+
+/// @dev Number of bytes of bytecode that precede the metadata inside the first
+/// of the two overlapping 32-byte reads.
+uint256 constant HEAD_WORD_PREFIX_LENGTH = 11;
+
+contract LibExtrospectBytecodeConstantsTest is Test {
+    /// Builds the 64 bytes that the two overlapping reads cover: an arbitrary
+    /// 11-byte bytecode prefix followed by 53 bytes of metadata, then returns
+    /// the two words with the pinned masks applied.
+    function maskWindow(bytes memory prefix, bytes memory metadata)
+        internal
+        pure
+        returns (bytes32 maskedHead, bytes32 maskedTail)
+    {
+        assertEq(prefix.length, HEAD_WORD_PREFIX_LENGTH);
+        assertEq(metadata.length, SOLIDITY_CBOR_METADATA_LENGTH);
+        bytes memory window = bytes.concat(prefix, metadata);
+        assertEq(window.length, 0x40);
+        uint256 headWord;
+        uint256 tailWord;
+        assembly ("memory-safe") {
+            headWord := mload(add(window, 0x20))
+            tailWord := mload(add(window, 0x40))
+        }
+        maskedHead = bytes32(headWord & SOLIDITY_CBOR_METADATA_HEAD_MASK);
+        maskedTail = bytes32(tailWord & SOLIDITY_CBOR_METADATA_TAIL_MASK);
+    }
+
+    /// Returns the final `SOLIDITY_CBOR_METADATA_LENGTH` bytes of `bytecode`.
+    function metadataOf(bytes memory bytecode) internal pure returns (bytes memory metadata) {
+        metadata = new bytes(SOLIDITY_CBOR_METADATA_LENGTH);
+        uint256 offset = bytecode.length - SOLIDITY_CBOR_METADATA_LENGTH;
+        for (uint256 i = 0; i < SOLIDITY_CBOR_METADATA_LENGTH; i++) {
+            metadata[i] = bytecode[offset + i];
+        }
+    }
+
+    /// The masks zero every byte outside the fixed CBOR structure, including
+    /// the bytecode that precedes the metadata, the 34-byte IPFS hash and the
+    /// 3-byte solc version, when all of those bytes are set.
+    function testSolidityCBORMetadataMasksZeroVariableBytes() external pure {
+        bytes memory ipfsHash = new bytes(34);
+        bytes memory solcVersion = new bytes(3);
+        bytes memory prefix = new bytes(HEAD_WORD_PREFIX_LENGTH);
+        for (uint256 i = 0; i < ipfsHash.length; i++) {
+            ipfsHash[i] = 0xFF;
+        }
+        for (uint256 i = 0; i < solcVersion.length; i++) {
+            solcVersion[i] = 0xFF;
+        }
+        for (uint256 i = 0; i < prefix.length; i++) {
+            prefix[i] = 0xFF;
+        }
+        bytes memory metadata = bytes.concat(hex"a264697066735822", ipfsHash, hex"64736f6c6343", solcVersion, hex"0033");
+
+        (bytes32 maskedHead, bytes32 maskedTail) = maskWindow(prefix, metadata);
+
+        assertEq(maskedHead, EXPECTED_MASKED_HEAD_WORD);
+        assertEq(maskedTail, EXPECTED_MASKED_TAIL_WORD);
+    }
+
+    /// The same two masked words come out of real metadata, i.e. an IPFS hash
+    /// and solc version that are not all set.
+    function testSolidityCBORMetadataMasksZeroRealVariableBytes() external pure {
+        bytes memory metadata = metadataOf(SOLIDITY_CBOR_RUNTIME_FIXTURE);
+        bytes memory prefix = new bytes(HEAD_WORD_PREFIX_LENGTH);
+
+        (bytes32 maskedHead, bytes32 maskedTail) = maskWindow(prefix, metadata);
+
+        assertEq(maskedHead, EXPECTED_MASKED_HEAD_WORD);
+        assertEq(maskedTail, EXPECTED_MASKED_TAIL_WORD);
+    }
+
+    /// The pinned hash is `keccak256` of the two masked words.
+    function testSolidityCBORMetadataMaskedHash() external pure {
+        assertEq(
+            keccak256(abi.encodePacked(EXPECTED_MASKED_HEAD_WORD, EXPECTED_MASKED_TAIL_WORD)),
+            SOLIDITY_CBOR_METADATA_MASKED_HASH
+        );
+    }
+
+    /// The trailer bytes the tail mask keeps encode a CBOR body length that is
+    /// `SOLIDITY_CBOR_METADATA_LENGTH` minus those 2 trailer bytes.
+    function testSolidityCBORMetadataLengthMatchesTrailer() external pure {
+        uint256 bodyLength = uint256(EXPECTED_MASKED_TAIL_WORD) & 0xFFFF;
+        assertEq(bodyLength, 51);
+        assertEq(bodyLength + 2, SOLIDITY_CBOR_METADATA_LENGTH);
+    }
+}

--- a/test/src/lib/LibExtrospectBytecode.constants.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.constants.t.sol
@@ -13,7 +13,7 @@ import {SOLIDITY_CBOR_RUNTIME_FIXTURE} from "test/concrete/SolidityCBORFixture.s
 
 /// @dev The two 32-byte words that the head and tail masks leave behind for
 /// bytecode ending in standard Solidity CBOR metadata. The head word is 11
-/// zeroed bytes of preceding bytecode, then metadata bytes 0-7
+/// zeroed bytes preceding the metadata, then metadata bytes 0-7
 /// `a2 64 69706673 5822`, then 13 zeroed bytes of IPFS hash.
 bytes32 constant EXPECTED_MASKED_HEAD_WORD = 0x0000000000000000000000a26469706673582200000000000000000000000000;
 
@@ -22,13 +22,13 @@ bytes32 constant EXPECTED_MASKED_HEAD_WORD = 0x0000000000000000000000a2646970667
 /// then metadata bytes 51-52 `0033`.
 bytes32 constant EXPECTED_MASKED_TAIL_WORD = 0x00000000000000000000000000000000000000000064736f6c63430000000033;
 
-/// @dev Number of bytes of bytecode that precede the metadata inside the first
+/// @dev Number of bytes that precede the metadata inside the first
 /// of the two overlapping 32-byte reads.
 uint256 constant HEAD_WORD_PREFIX_LENGTH = 11;
 
 contract LibExtrospectBytecodeConstantsTest is Test {
     /// Builds the 64 bytes that the two overlapping reads cover: an arbitrary
-    /// 11-byte bytecode prefix followed by 53 bytes of metadata, then returns
+    /// 11-byte prefix followed by 53 bytes of metadata, then returns
     /// the two words with the pinned masks applied.
     function maskWindow(bytes memory prefix, bytes memory metadata)
         internal
@@ -59,7 +59,7 @@ contract LibExtrospectBytecodeConstantsTest is Test {
     }
 
     /// The masks zero every byte outside the fixed CBOR structure, including
-    /// the bytecode that precedes the metadata, the 34-byte IPFS hash and the
+    /// the 11 bytes that precede the metadata, the 34-byte IPFS hash and the
     /// 3-byte solc version, when all of those bytes are set.
     function testSolidityCBORMetadataMasksZeroVariableBytes() external pure {
         bytes memory ipfsHash = new bytes(34);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/67

## Claim verified against main (`32f7325`)

The `53` literal is repeated in `tryTrimSolidityCBORMetadata` twice (`length >= 53`, `sub(length, 53)`), and two further constants encode the same layout without saying so: `maskB`'s trailing `FFFF` window and the pinned `expectedHash`.

One correction to the issue as filed: `0x0033` is not literally present in `maskB`. `maskB` only *keeps* the final two metadata bytes; the value `0033` (51, the CBOR body length) is pinned solely inside `expectedHash`. So the coupling is `length literal` <-> `mask window` <-> `pinned hash`, which is if anything more opaque than the issue describes — nothing in the source states that the kept trailer bytes are `0033` at all.

I derived the layout independently and confirmed it: masking a 64-byte window of `<11 bytes>||<53-byte canonical trailer>` with the two masks yields

```
head = 0x0000000000000000000000a26469706673582200000000000000000000000000
tail = 0x00000000000000000000000000000000000000000064736f6c63430000000033
```

and `cast keccak head||tail` = `0x0e55864b80a56accebaca64500e23598f6acfb743a5475323f0b7f2d0d268c62`, i.e. exactly the pinned hash.

## Change

- `src/lib/LibExtrospectBytecode.sol`: four named file-level constants — `SOLIDITY_CBOR_METADATA_LENGTH`, `SOLIDITY_CBOR_METADATA_HEAD_MASK`, `SOLIDITY_CBOR_METADATA_TAIL_MASK`, `SOLIDITY_CBOR_METADATA_MASKED_HASH` — each documenting which metadata bytes it covers, with the function referring to them instead of the literals.
- `test/src/lib/LibExtrospectBytecode.constants.t.sol` (new, 4 tests): builds the canonical trailer from its structural bytes, applies the pinned masks, and asserts the masked words and their `keccak256` — so the four encodings are now checked against each other by the suite rather than only by a reader counting hex digits. Also asserts the kept trailer bytes decode to `51`, and that `51 + 2 == SOLIDITY_CBOR_METADATA_LENGTH`.

## No verdict changes: the compiled bytecode is byte-identical

`ExtrospectConstantsTest` pins `EXTROSPECT_CREATION_BYTECODE_V1`, `EXTROSPECT_RUNTIME_CODEHASH_V1` and `EXTROSPECT_ZOLTU_ADDRESS_V1`, and all three still pass unchanged. Nothing about what the library concludes can have moved, because the deployed bytes did not move.

This constrained the refactor and is worth recording: two other formulations of the same change **did** drift the pins and were discarded.

| formulation | pins |
| --- | --- |
| extra `metadataLength` local for use inside the assembly block | drifted (creation bytecode hash `0xabdfa58d…`) |
| constants referenced directly inside the assembly block, locals removed | drifted (creation bytecode hash `0x615f6b01…`) |
| **kept `maskA`/`maskB`/`expectedHash` locals exactly as they were, only their initialisers now name constants; length constant used directly in assembly** | **unchanged (`0x5a56765a…`)** |

## Tests

`nix develop -c forge test`, excluding `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` (needs `ARBITRUM_RPC_URL`, absent locally — costs 7 tests; that gap is https://github.com/rainlanguage/rain.extrospection/issues/85):

- main `32f7325`: **307 passed / 0 failed / 0 skipped**
- this branch: **311 passed / 0 failed / 0 skipped** (307 + 4 new)

`nix develop -c forge fmt --check` clean.

Pre-existing, unrelated: with some fuzz seeds `testCheckNoMetadataPassesFuzz` fails with `vm.etch: failed to create bytecode: Eip7702 is not 23 bytes long`. Deterministic with `--fuzz-seed 0x1` on this branch (310 passed / 1 failed / 311 total), and reproduced on **main** at `32f7325` with the seed of the run that first hit it (`0xf8a9d5fa8a2c3fb0ee9c409ebd7420b340283d3275ec028d158b913437f452d4`). That is https://github.com/rainlanguage/rain.extrospection/issues/86, not this diff.

## Adversarial mutation pass

Run as `forge test --no-match-contract ExtrospectConstantsTest --no-match-path test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol`. `ExtrospectConstantsTest` is excluded because it pins deployed bytecode and therefore fails under *every* source mutation, which would report KILLED for everything and measure nothing.

Each mutant was applied by `sed` to `src/lib/LibExtrospectBytecode.sol`, the diff was checked to be non-empty before running (a no-op edit is recorded as `NO-OP-SED`, never as a kill), and every row below ran the full **308 tests** — proof the suite compiled and executed rather than erroring out.

| # | mutant | result | tests failed | killed by |
| --- | --- | --- | --- | --- |
| m01 | `SOLIDITY_CBOR_METADATA_LENGTH` 53 -> 54 | KILLED | 7 | new constants tests + `…Exactly53BytesValid`, `…BytecodeReal`, `…BytecodeContrived` |
| m02 | `SOLIDITY_CBOR_METADATA_LENGTH` 53 -> 52 | KILLED | 6 | new constants tests + `…Exactly53BytesValid`, `…BytecodeReal`, `…BytecodeContrived` |
| m03 | `HEAD_MASK` drops the last kept structural byte (`5822` -> `58`) | KILLED | 11 | new mask tests + trim/checkNoMetadata suites |
| m04 | `HEAD_MASK` widened one byte into the IPFS hash | KILLED | 11 | new mask tests + trim/checkNoMetadata suites |
| m05 | `TAIL_MASK` stops keeping the 2-byte length trailer | KILLED | 11 | new mask tests + trim/checkNoMetadata suites |
| m06 | `TAIL_MASK` widened one byte into the solc version | KILLED | 3 | `testSolidityCBORMetadataMasksZeroVariableBytes` deterministically; otherwise only the two fuzz tests |
| m07 | `MASKED_HASH` last nibble flipped | KILLED | 10 | `testSolidityCBORMetadataMaskedHash` + trim/checkNoMetadata suites |
| m08 | `length >= LENGTH` -> `length > LENGTH` | KILLED | 4 | `…Exactly53BytesValid`, `…BytecodeContrived`, fuzz |
| m09 | trim shortens by `52` instead of the shared constant | KILLED | 4 | `…Exactly53BytesValid`, `…BytecodeReal`, `…BytecodeContrived`, fuzz |
| m10 | head and tail masks swapped | KILLED | 10 | trim/checkNoMetadata suites |
| m11 | head word read shifted one byte earlier (`sub(end, 0x21)`) | KILLED | 10 | trim/checkNoMetadata suites |

11/11 killed, 0 survived.

m06 is the one worth reading. Widening `TAIL_MASK` by one byte over the *first* byte of the solc version is invisible to every existing fixture, because every fixture is solc `0.8.25`, whose version bytes start `00` — masking in a zero changes no hash. The mutant silently narrows what the library will trim (any contract built by a solc major version `!= 0` would stop trimming). Before this PR only the two fuzz tests caught it, and only by chance of the seed; `testSolidityCBORMetadataMasksZeroVariableBytes` now kills it deterministically by setting every variable byte to `0xff`.

## Deliberately not done

The triage note points at Protofire L02 (Acknowledged), i.e. reading the metadata length dynamically instead of assuming 53. That changes what the library trims and therefore what `checkCBORTrimmedBytecodeHash` / `checkNoSolidityCBORMetadata` conclude about a contract, so it is not in this PR.

## QA
- Discriminating tests: `testSolidityCBORMetadataMasksZeroVariableBytes`, `testSolidityCBORMetadataMasksZeroRealVariableBytes`, `testSolidityCBORMetadataMaskedHash`, `testSolidityCBORMetadataLengthMatchesTrailer` — all four are new and cannot run on base at all, since base has no named constants to import; against base's inlined literals they are the same assertions and pass, which is the point (the refactor is value-preserving). What they discriminate is future drift: each fails the moment any one of the four coupled encodings changes without the others, shown by m01-m07 below.
- Mutations applied: `SOLIDITY_CBOR_METADATA_LENGTH` 53->54 -> killed by `testSolidityCBORMetadataLengthMatchesTrailer` + `testSolidityCBORMetadataMasksZero*`; 53->52 -> same; `HEAD_MASK` `5822`->`58` -> killed by `testSolidityCBORMetadataMasksZeroVariableBytes`; `HEAD_MASK` widened into the IPFS hash -> same; `TAIL_MASK` drops the length trailer -> same; `TAIL_MASK` widened into the solc version -> killed ONLY deterministically by `testSolidityCBORMetadataMasksZeroVariableBytes`; `MASKED_HASH` last nibble flipped -> killed by `testSolidityCBORMetadataMaskedHash`; `length >= L` -> `length > L`, `sub(length, L)` -> `sub(length, 52)`, masks swapped, `sub(end, 0x20)` -> `sub(end, 0x21)` -> killed by the pre-existing trim tests. 11 applied, 11 killed, 0 survived, 308 tests ran per mutant. Full table above.
- Oracle: the Solidity metadata encoding documented at https://docs.soliditylang.org/en/latest/metadata.html — `a2 64 "ipfs" 5822 <34> 64 "solc" 43 <3> 0033` — written out byte by byte in the test with the variable regions set to `0xff`, never read back from `LibExtrospectBytecode`. The expected masked words are literals in the test; their `keccak256` was computed out of band with `cast keccak` before the test existed and matches the pinned hash.
- Category check: the issue asks for the 53-byte length to stop being an unshared literal repeated across four coupled encodings (length comparison, trim arithmetic, mask window, pinned hash). All four are covered: the first two now name one constant, the latter two are named constants whose agreement with the first is asserted by the new tests. The issue's own out-of-scope note (Protofire L02, dynamic length read) is left alone because it changes verdicts.
