### PR TITLE
Document and pin isERC1167Proxy's bytecode-only verdict

### DIFF
--- a/src/lib/LibExtrospectERC1167Proxy.sol
+++ b/src/lib/LibExtrospectERC1167Proxy.sol
@@ -37,10 +37,15 @@ uint256 constant ERC1167_IMPLEMENTATION_ADDRESS_OFFSET = ERC1167_PREFIX_LENGTH +
 library LibExtrospectERC1167Proxy {
     /// @notice Checks if the given bytecode is an ERC1167 proxy. If so,
     /// returns the implementation address.
+    /// The verdict is a function of the 45 bytes alone. It is the same whether
+    /// or not the implementation account exists or has code.
     /// @param bytecode The bytecode to check.
     /// @return result True if the bytecode is an ERC1167 proxy.
     /// @return implementationAddress The address of the implementation contract.
-    /// This is only valid if `result` is true, else it is zero.
+    /// This is only valid if `result` is true, else it is zero. When `result`
+    /// is true this is whatever address the bytecode encodes, which includes
+    /// `address(0)`, so `result` is the only discriminator between a proxy and
+    /// a non-proxy.
     function isERC1167Proxy(bytes memory bytecode) internal pure returns (bool result, address implementationAddress) {
         unchecked {
             {

--- a/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
+++ b/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
@@ -110,6 +110,40 @@ contract LibExtrospectERC1167ProxyTest is Test {
         assertEq(implementationResult, implementation);
     }
 
+    /// A 45-byte clone encoding `address(0)` as the implementation is detected
+    /// as a proxy, so `(true, address(0))` is a reachable return value and the
+    /// returned address alone does not distinguish a proxy from a non-proxy.
+    function testIsERC1167ProxyZeroImplementation() external pure {
+        bytes memory bytecode = abi.encodePacked(ERC1167_PREFIX, address(0), ERC1167_SUFFIX);
+        assertEq(bytecode.length, ERC1167_PROXY_LENGTH);
+        (bool result, address implementationResult) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertTrue(result);
+        assertEq(implementationResult, address(0));
+
+        (bool emptyResult, address emptyImplementationResult) = LibExtrospectERC1167Proxy.isERC1167Proxy(hex"");
+        assertFalse(emptyResult);
+        assertEq(emptyImplementationResult, implementationResult);
+    }
+
+    /// The verdict is a function of the bytecode alone, so the same clone
+    /// bytecode gets the same result whether or not the implementation account
+    /// has code.
+    function testIsERC1167ProxyImplementationCodeIrrelevant() external {
+        address implementation = address(uint160(uint256(keccak256("no code at this address"))));
+        bytes memory bytecode = abi.encodePacked(ERC1167_PREFIX, implementation, ERC1167_SUFFIX);
+
+        assertEq(implementation.code.length, 0);
+        (bool result, address implementationResult) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertTrue(result);
+        assertEq(implementationResult, implementation);
+
+        vm.etch(implementation, hex"00");
+        assertEq(implementation.code.length, 1);
+        (bool resultWithCode, address implementationResultWithCode) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertEq(resultWithCode, result);
+        assertEq(implementationResultWithCode, implementationResult);
+    }
+
     /// Compare the fail case of the slow implementation to the fast.
     function testIsERC1167ProxySlowFail(bytes memory bytecode) external pure {
         (bool result, address implementationResult) = LibExtrospectionSlow.isERC1167ProxySlow(bytecode);
@@ -126,6 +160,18 @@ contract LibExtrospectERC1167ProxyTest is Test {
         (bool resultFast, address implementationResultFast) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
         assertTrue(result);
         assertEq(result, resultFast);
+        assertEq(implementationResult, implementationResultFast);
+    }
+
+    /// The slow and fast implementations agree on a clone encoding
+    /// `address(0)` as the implementation.
+    function testIsERC1167ProxySlowZeroImplementation() external pure {
+        bytes memory bytecode = abi.encodePacked(ERC1167_PREFIX, address(0), ERC1167_SUFFIX);
+        (bool result, address implementationResult) = LibExtrospectionSlow.isERC1167ProxySlow(bytecode);
+        (bool resultFast, address implementationResultFast) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertTrue(result);
+        assertEq(result, resultFast);
+        assertEq(implementationResult, address(0));
         assertEq(implementationResult, implementationResultFast);
     }
 

--- a/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
+++ b/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
@@ -125,23 +125,15 @@ contract LibExtrospectERC1167ProxyTest is Test {
         assertEq(emptyImplementationResult, implementationResult);
     }
 
-    /// The verdict is a function of the bytecode alone, so the same clone
-    /// bytecode gets the same result whether or not the implementation account
-    /// has code.
-    function testIsERC1167ProxyImplementationCodeIrrelevant() external {
+    /// A clone whose implementation account has no code is detected as a
+    /// proxy, and the codeless address is returned.
+    function testIsERC1167ProxyImplementationWithoutCode() external view {
         address implementation = address(uint160(uint256(keccak256("no code at this address"))));
-        bytes memory bytecode = abi.encodePacked(ERC1167_PREFIX, implementation, ERC1167_SUFFIX);
-
         assertEq(implementation.code.length, 0);
+        bytes memory bytecode = abi.encodePacked(ERC1167_PREFIX, implementation, ERC1167_SUFFIX);
         (bool result, address implementationResult) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
         assertTrue(result);
         assertEq(implementationResult, implementation);
-
-        vm.etch(implementation, hex"00");
-        assertEq(implementation.code.length, 1);
-        (bool resultWithCode, address implementationResultWithCode) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
-        assertEq(resultWithCode, result);
-        assertEq(implementationResultWithCode, implementationResult);
     }
 
     /// Compare the fail case of the slow implementation to the fast.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/69

## What reproduced

Fresh clone at `main` (`32f7325`), `nix develop -c forge test`. Every claim in the issue holds, including the EVM claim underneath it: a 45-byte clone of `address(0)`, `vm.etch`ed and called, succeeds with empty returndata. `LibExtrospectionSlow.isERC1167ProxySlow` returns the same `(true, address(0))`, so this is the library's verdict rather than an assembly bug.

## What is in this PR

Only the half that leaves every verdict unchanged.

- `isERC1167Proxy` NatSpec now states that the verdict is a function of the 45 bytes alone, that it does not depend on whether the implementation account exists or has code, and that `address(0)` is a reachable `implementationAddress` when `result` is true - so `result` is the only discriminator.
- Three deterministic tests pin exactly those verdicts. Before this the zero-implementation case was reachable only through the `address` fuzzer in `testIsERC1167ProxySuccess` and was never named.

No source behaviour changes. `isERC1167Proxy` returns the same tuple for every input it did before.

## What is NOT in this PR

The rest of the issue can only be addressed by changing what the library concludes - rejecting `address(0)`, or making the verdict depend on the implementation account. The option space is posted on the issue for a human ruling. If Option B (reject `address(0)`) is chosen, `testIsERC1167ProxyZeroImplementation` and `testIsERC1167ProxySlowZeroImplementation` are the two tests that flip, which is the point of pinning them.

## Adversarial mutation pass

Harness: `nix develop -c forge test --fuzz-seed 1 --no-match-contract ExtrospectConstantsTest --no-match-test 'testCheckCBORTrimmedBytecodeHash(Failure|MetadataNotTrimmed|Success)'`, with `cache/fuzz` cleared before every run.

- `ExtrospectConstantsTest` pins deployed bytecode, so it fails under every source mutation and would report KILLED for everything. Excluded; it measures nothing here.
- The three `testCheckCBORTrimmedBytecodeHash{Success,Failure,MetadataNotTrimmed}` tests need `ARBITRUM_RPC_URL`, which is absent. Excluded by name rather than by file, so the other four tests in `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` still run.
- The seed is pinned because `testCheckNoMetadata{Passes,Reverts}Fuzz` flake on EIP-7702-shaped fuzz input (#86) and the stored failure corpus makes the flake sticky.

**Baseline on this branch: 311 passed / 0 failed / 311 total** (317 tests exist; 6 excluded as above). On `main` before this PR the same filter gives 308 tests.

Every mutant was verified to have actually changed the file (md5 before/after) and to have actually run tests (a `Ran N test suites` line), so a no-op edit or a compile failure cannot be mistaken for a surviving mutant.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | success path `result = true` -> `result = false` | KILLED (6 failed) | `testIsERC1167ProxySuccess`, `testIsERC1167ProxyImplementationAddressIsCleanWord`, `testIsERC1167ProxySlowSuccess`, **`testIsERC1167ProxyZeroImplementation`**, **`testIsERC1167ProxySlowZeroImplementation`**, **`testIsERC1167ProxyImplementationWithoutCode`** |
| M2 | drop the prefix hash check | KILLED (2 failed) | `testIsERC1167ProxyPrefixFail`, `testIsERC1167ProxyPrefixFail45Bytes` |
| M3 | drop the suffix hash check | KILLED (3 failed) | `testIsERC1167ProxySuffixFail`, `testIsERC1167ProxySuffixFail45Bytes`, `testIsERC1167ProxySlowFail` |
| M4 | `ERC1167_IMPLEMENTATION_ADDRESS_OFFSET` 20 -> 19 | KILLED (6 failed) | same six as M1 |
| M5 | address mask `type(uint160).max` -> `type(uint256).max` | KILLED (1 failed) | `testIsERC1167ProxyImplementationAddressIsCleanWord` |
| M6 | extract the address unconditionally (`if (result)` -> `if (true)`) | KILLED (6 failed) | `testIsERC1167ProxyPrefixFail`, `testIsERC1167ProxyPrefixFail45Bytes`, `testIsERC1167ProxySuffixFail`, `testIsERC1167ProxySuffixFail45Bytes`, `testIsERC1167ProxyBothPrefixAndSuffixFail`, `testIsERC1167ProxySlowFail` |
| M7 | length check `!=` -> `>` | KILLED (1 failed) | `testIsERC1167ProxyLength44` |
| M8 | **Option B**: `result &= implementationAddress != 0` in the fast path | KILLED (5 failed) | `testIsERC1167ProxySuccess`, `testIsERC1167ProxyImplementationAddressIsCleanWord`, `testIsERC1167ProxySlowSuccess`, **`testIsERC1167ProxyZeroImplementation`**, **`testIsERC1167ProxySlowZeroImplementation`** |
| M9 | **Option B** in `LibExtrospectionSlow.isERC1167ProxySlow` | KILLED (3 failed) | `testIsERC1167ProxySlowFail`, `testIsERC1167ProxySlowSuccess`, **`testIsERC1167ProxySlowZeroImplementation`** |

**9 mutants, 9 killed, 0 survived.** Bold entries are tests added by this PR.

### Control: do the new tests earn their place?

M8 and M9 are the mutants that implement the verdict change the issue asks for, so they are the ones the new tests exist to catch. Re-running just those two with this PR's three tests also excluded:

| # | Result without the PR's tests | Killed by |
|---|---|---|
| M8 | still KILLED (3 failed) | `testIsERC1167ProxySuccess`, `testIsERC1167ProxyImplementationAddressIsCleanWord`, `testIsERC1167ProxySlowSuccess` |
| M9 | still KILLED (2 failed) | `testIsERC1167ProxySlowFail`, `testIsERC1167ProxySlowSuccess` |

So the pre-existing suite already kills both - but only because the `address` fuzzer draws `address(0)` out of its dictionary inside 2048 runs. Nothing in the suite asked for that input. The three tests here do not close a hole in the kill set; they convert a fuzz-dictionary-dependent kill into a deterministic one and put the disputed verdict where a human ruling can land on it. Claiming more than that would be claiming a fuzz run is a proof.

## QA
- Discriminating tests: `testIsERC1167ProxyZeroImplementation`, `testIsERC1167ProxySlowZeroImplementation`, `testIsERC1167ProxyImplementationWithoutCode`. They do NOT fail on base, and that is deliberate - this PR changes no behaviour, so they pass on `main` as well. What they fail on is the Option B mutant (M8/M9), verified by applying it and watching each turn red; see the mutation table. What was verified against base is the finding itself: the issue's repro was re-executed on a fresh clone at `main` `32f7325` and passes there - `(true, address(0))` for a zero clone, `(true, 0xBEEF)` for a codeless one, and a `vm.etch`ed zero clone answering a call with success and empty returndata.
- Mutations applied: 9 mutants, 9 killed, 0 survived. `result = true` -> `false` -> killed by 6 tests incl. all three new ones; drop prefix hash check -> `testIsERC1167ProxyPrefixFail{,45Bytes}`; drop suffix hash check -> `testIsERC1167ProxySuffixFail{,45Bytes}` + `testIsERC1167ProxySlowFail`; `ERC1167_IMPLEMENTATION_ADDRESS_OFFSET` 20 -> 19 -> same 6 as M1; address mask `uint160` -> `uint256` -> `testIsERC1167ProxyImplementationAddressIsCleanWord`; `if (result)` -> `if (true)` -> 6 fail-path tests; length `!=` -> `>` -> `testIsERC1167ProxyLength44`; Option B zero-guard in the fast path -> `testIsERC1167ProxyZeroImplementation` + `testIsERC1167ProxySlowZeroImplementation` (plus 3 pre-existing fuzz tests); Option B zero-guard in `isERC1167ProxySlow` -> `testIsERC1167ProxySlowZeroImplementation` (plus 2 pre-existing fuzz tests). Full table above, including the control run showing what the pre-existing suite kills unaided.
- Oracle: EIP-1167 (https://eips.ethereum.org/EIPS/eip-1167) for the 45-byte layout, the 10-byte prefix, the 15-byte suffix and the absence of any constraint on the implementation address; EVM semantics for DELEGATECALL into an account with no code (success, empty returndata). Expected values come from those, not from reading this library. `LibExtrospectionSlow.isERC1167ProxySlow` is the independent second implementation and agrees on every case added here.
- Category check: the issue asks for (a) zero/codeless implementations being accepted and (b) `(true, address(0))` being indistinguishable from `(false, address(0))` on the address alone. Both are covered here as NatSpec plus pinned tests. Neither is *fixed*, because every available fix changes a verdict the library reaches, which is a human decision - the option space (A status quo, B reject `address(0)`, C account-taking sibling, D not available) is posted on the issue for a ruling.
