### PR TITLE
Pin isERC1167Proxy EOF behaviour in NatSpec and tests

### DIFF
--- a/src/lib/LibExtrospectERC1167Proxy.sol
+++ b/src/lib/LibExtrospectERC1167Proxy.sol
@@ -37,6 +37,9 @@ uint256 constant ERC1167_IMPLEMENTATION_ADDRESS_OFFSET = ERC1167_PREFIX_LENGTH +
 library LibExtrospectERC1167Proxy {
     /// @notice Checks if the given bytecode is an ERC1167 proxy. If so,
     /// returns the implementation address.
+    /// EOF bytecode does not revert. An EOF container begins with `0xEF00`,
+    /// which is not `ERC1167_PREFIX`, so EOF bytecode returns
+    /// `(false, address(0))`.
     /// @param bytecode The bytecode to check.
     /// @return result True if the bytecode is an ERC1167 proxy.
     /// @return implementationAddress The address of the implementation contract.

--- a/test/src/concrete/Extrospect.isERC1167Proxy.t.sol
+++ b/test/src/concrete/Extrospect.isERC1167Proxy.t.sol
@@ -19,4 +19,18 @@ contract ExtrospectIsERC1167ProxyTest is ExtrospectEquivalence {
         assertEq(extIsProxy, libIsProxy);
         assertEq(extImpl, libImpl);
     }
+
+    /// EOF bytecode of exactly the ERC1167 proxy length returns
+    /// `(false, address(0))` through the external entry point rather than
+    /// reverting.
+    function testIsERC1167ProxyEquivalenceEOF() external view {
+        bytes memory bytecode =
+            hex"EF0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        (bool extIsProxy, address extImpl) = extrospect.isERC1167Proxy(bytecode);
+        (bool libIsProxy, address libImpl) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertFalse(extIsProxy);
+        assertEq(extImpl, address(0));
+        assertEq(extIsProxy, libIsProxy);
+        assertEq(extImpl, libImpl);
+    }
 }

--- a/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
+++ b/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
@@ -11,6 +11,7 @@ import {
     ERC1167_PREFIX_LENGTH,
     ERC1167_SUFFIX_LENGTH
 } from "src/lib/LibExtrospectERC1167Proxy.sol";
+import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
 import {LibExtrospectionSlow} from "test/lib/LibExtrospectionSlow.sol";
 
 /// @title LibExtrospectERC1167ProxyTest
@@ -41,6 +42,55 @@ contract LibExtrospectERC1167ProxyTest is Test {
         (bool result, address impl) = LibExtrospectERC1167Proxy.isERC1167Proxy(extended);
         assertFalse(result);
         assertEq(impl, address(0));
+    }
+
+    /// EOF bytecode shorter than an ERC1167 proxy is not a proxy and does not
+    /// revert. Hits the length-check early return.
+    function testIsERC1167ProxyEOFShort() external pure {
+        bytes memory bytecode = hex"EF00";
+        assertTrue(LibExtrospectBytecode.isEOFBytecode(bytecode));
+        assertTrue(bytecode.length != ERC1167_PROXY_LENGTH);
+        (bool result, address implementation) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertFalse(result);
+        assertEq(implementation, address(0));
+    }
+
+    /// An EOF container of a length other than 45 bytes is not a proxy and does
+    /// not revert. Hits the length-check early return.
+    function testIsERC1167ProxyEOFContainer() external pure {
+        bytes memory bytecode = hex"EF000101000402000100010400000000800000FE";
+        assertTrue(LibExtrospectBytecode.isEOFBytecode(bytecode));
+        assertTrue(bytecode.length != ERC1167_PROXY_LENGTH);
+        (bool result, address implementation) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertFalse(result);
+        assertEq(implementation, address(0));
+    }
+
+    /// EOF bytecode of exactly the ERC1167 proxy length is not a proxy and does
+    /// not revert. Reaches the prefix hash comparison because the length check
+    /// passes.
+    function testIsERC1167ProxyEOFProxyLength() external pure {
+        bytes memory bytecode =
+            hex"EF0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        assertTrue(LibExtrospectBytecode.isEOFBytecode(bytecode));
+        assertEq(bytecode.length, ERC1167_PROXY_LENGTH);
+        (bool result, address implementation) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertFalse(result);
+        assertEq(implementation, address(0));
+    }
+
+    /// EOF bytecode carrying a valid ERC1167 suffix at the correct length is
+    /// not a proxy and does not revert. The suffix hash matches and only the
+    /// prefix hash rejects it, so the implementation address is never read.
+    function testIsERC1167ProxyEOFWithValidSuffix() external pure {
+        bytes memory bytecode = abi.encodePacked(
+            hex"EF000000000000000000", address(0x1111111111111111111111111111111111111111), ERC1167_SUFFIX
+        );
+        assertTrue(LibExtrospectBytecode.isEOFBytecode(bytecode));
+        assertEq(bytecode.length, ERC1167_PROXY_LENGTH);
+        (bool result, address implementation) = LibExtrospectERC1167Proxy.isERC1167Proxy(bytecode);
+        assertFalse(result);
+        assertEq(implementation, address(0));
     }
 
     /// ERC1167 has known prefix so any other prefix is not a proxy.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/72

## Claim verified against main (`32f7325`)

`grep -n checkNotEOFBytecode src/lib/*.sol` — the gate is called by
`tryTrimSolidityCBORMetadata`, `scanEVMOpcodesReachableInBytecode` and
`scanEVMOpcodesPresentInBytecode` in `LibExtrospectBytecode` (and reached from
`LibExtrospectMetamorphic` through the reachable scan). `isERC1167Proxy` in
`LibExtrospectERC1167Proxy` does not call it. It is the only `bytes memory`
entry point in `src/` without an EOF gate. Behaviour on EOF input confirmed:
returns `(false, address(0))`, no revert.

## What this PR does

The half of the finding that changes no verdict:

- `src/lib/LibExtrospectERC1167Proxy.sol` — three lines of NatSpec on
  `isERC1167Proxy` stating the current behaviour on EOF input.
- `test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol` — four
  deterministic tests pinning it, each asserting the input is EOF by
  `LibExtrospectBytecode.isEOFBytecode` before asserting the result:
  - `testIsERC1167ProxyEOFShort` — `0xEF00`, length early return.
  - `testIsERC1167ProxyEOFContainer` — a 20-byte EOF container, length early
    return.
  - `testIsERC1167ProxyEOFProxyLength` — 45-byte EOF blob, reaches the prefix
    hash comparison.
  - `testIsERC1167ProxyEOFWithValidSuffix` — 45-byte EOF blob carrying a valid
    `ERC1167_SUFFIX`, so only the prefix hash rejects it.
- `test/src/concrete/Extrospect.isERC1167Proxy.t.sol` —
  `testIsERC1167ProxyEquivalenceEOF` pins the same through the external entry
  point.

## What this PR does NOT do

Adding `checkNotEOFBytecode` to `isERC1167Proxy` changes what the library
concludes about EOF-prefixed bytecode — `(false, address(0))` today, a revert
after. That is a verdict change and it is not mine to make. The option space is
posted on the issue for a human ruling; this PR pins the status quo so whichever
way that lands, it lands as a deliberate change to a stated behaviour rather
than a silent one.

## Source change alters no bytecode

The only `src/` change is NatSpec. `ExtrospectConstantsTest` (which pins
`EXTROSPECT_CREATION_BYTECODE_V1`, `EXTROSPECT_ZOLTU_ADDRESS_V1` and
`EXTROSPECT_RUNTIME_CODEHASH_V1`) passes unchanged on this branch, which is the
proof.

## Tests ran

Toolchain: `nix develop -c forge test`, `nix develop -c forge fmt`.

Baseline on main (`32f7325`), full suite, no exclusions: **314 tests, 3 failed**
— the 3 failures are all in
`test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` and are
`ARBITRUM_RPC_URL`-dependent (issue #85), absent in this environment.

Excluding only that file, so `ExtrospectConstantsTest` still runs:

| | tests | passed | failed |
|---|---|---|---|
| main `32f7325` | 307 | 307 | 0 |
| this branch | 312 | 312 | 0 |

The 5 new tests, from that run:

```
[PASS] testIsERC1167ProxyEOFShort() (gas: 860)
[PASS] testIsERC1167ProxyEOFContainer() (gas: 862)
[PASS] testIsERC1167ProxyEOFProxyLength() (gas: 1172)
[PASS] testIsERC1167ProxyEOFWithValidSuffix() (gas: 1425)
[PASS] testIsERC1167ProxyEquivalenceEOF() (gas: 7255)
```

## Adversarial mutation pass

Mutation harness excludes two files, both deliberately:

- `ExtrospectConstantsTest` — pins deployed bytecode, so it fails under every
  source mutation and would report KILLED for every mutant while measuring
  nothing.
- `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` —
  needs `ARBITRUM_RPC_URL`. Excluding the whole file drops 7 tests to skip the
  3 that fail without it, so 4 passing CBOR-trim tests are lost from the
  mutation oracle. None of them touch `LibExtrospectERC1167Proxy`, which is the
  mutated unit.

Mutation baseline with both exclusions: **309 passed / 0 failed / 0 skipped**
(main under the same exclusions: 304). Every mutant re-ran the whole 309-test
suite; the "tests run" column is the count the harness reported, so a mutant
that failed to compile or matched no tests would show as something other than
309.

All mutants in `src/lib/LibExtrospectERC1167Proxy.sol`.

| # | Mutation | Tests run | Result | Failing tests |
|---|---|---|---|---|
| M1 | Insert `LibExtrospectBytecode.checkNotEOFBytecode(bytecode);` at the top of `isERC1167Proxy` — the exact "future author fixes it into a revert" change the issue names | 309 | **KILLED** (11 failed) | all 5 new tests, deterministically; plus 6 pre-existing fuzz tests that happened to draw `0xEF00` |
| M2 | `bytecode.length != ERC1167_PROXY_LENGTH` → `<` | 309 | **KILLED** (2 failed) | `testIsERC1167ProxyLength46`, `testIsERC1167ProxyPrefixFail` |
| M3 | prefix hash comparison → `and(result, 1)` | 309 | **KILLED** (3 failed) | **`testIsERC1167ProxyEOFWithValidSuffix`** (new), `testIsERC1167ProxyPrefixFail`, `testIsERC1167ProxyPrefixFail45Bytes` |
| M4 | suffix hash comparison → `and(result, 1)` | 309 | **KILLED** (3 failed) | `testIsERC1167ProxySlowFail`, `testIsERC1167ProxySuffixFail`, `testIsERC1167ProxySuffixFail45Bytes` |
| M5 | `implementationAddressMask` `type(uint160).max` → `type(uint168).max` | 309 | **KILLED** (1 failed) | `testIsERC1167ProxyImplementationAddressIsCleanWord` |
| M6 | `ERC1167_PREFIX_START` `0x20` → `0x21` | 309 | **KILLED** (3 failed) | `testIsERC1167ProxyImplementationAddressIsCleanWord`, `testIsERC1167ProxySlowSuccess`, `testIsERC1167ProxySuccess` |
| M7 | `if (result)` guarding the address read → `if (true)` | 309 | **KILLED** (7 failed) | **`testIsERC1167ProxyEOFWithValidSuffix`** (new), `testIsERC1167ProxyBothPrefixAndSuffixFail`, `testIsERC1167ProxyPrefixFail`, `testIsERC1167ProxyPrefixFail45Bytes`, `testIsERC1167ProxySlowFail`, `testIsERC1167ProxySuffixFail`, `testIsERC1167ProxySuffixFail45Bytes` |


7 mutants, 7 killed, 0 survived.

Honest note on M1: it was already killed on main, but only by six pre-existing
**fuzz** tests that happened to draw `0xEF00`-prefixed bytes
(`testIsERC1167ProxyLength`, `testIsERC1167ProxyPrefixFail`,
`testIsERC1167ProxyPrefixFail45Bytes`, `testIsERC1167ProxyBothPrefixAndSuffixFail`,
`testIsERC1167ProxySlowFail`, `testIsERC1167ProxyEquivalenceFuzz`). That is
seed-dependent, not a pin. The five new tests kill it deterministically, which
is the coverage this PR adds.

M3 and M7 are killed deterministically by `testIsERC1167ProxyEOFWithValidSuffix`
specifically because it is the only case in the file where a 45-byte input has a
matching suffix and a non-matching prefix, so it isolates the prefix comparison
and the `if (result)` guard on the address read.

## QA
- Discriminating tests: `testIsERC1167ProxyEOFShort`, `testIsERC1167ProxyEOFContainer`, `testIsERC1167ProxyEOFProxyLength`, `testIsERC1167ProxyEOFWithValidSuffix`, `testIsERC1167ProxyEquivalenceEOF` - each fails on the M1 mutant (EOF gate inserted into `isERC1167Proxy`) with `EOFBytecodeNotSupported()`, verified by running the mutated source; `testIsERC1167ProxyEOFWithValidSuffix` additionally fails on the M3 and M7 mutants. They cannot "fail on base" in the usual sense because they pin behaviour that already exists on base — the base they discriminate against is the gated variant the issue warns a future author may introduce.
- Mutations applied: 7 mutants in `src/lib/LibExtrospectERC1167Proxy.sol`, 7 killed, 0 survived - `isERC1167Proxy` entry -> insert `checkNotEOFBytecode` -> all 5 new tests; `bytecode.length !=` -> `<` -> `testIsERC1167ProxyLength46`; prefix hash comparison -> `and(result, 1)` -> `testIsERC1167ProxyEOFWithValidSuffix`; suffix hash comparison -> `and(result, 1)` -> `testIsERC1167ProxySuffixFail45Bytes`; `type(uint160).max` -> `type(uint168).max` -> `testIsERC1167ProxyImplementationAddressIsCleanWord`; `ERC1167_PREFIX_START` `0x20` -> `0x21` -> `testIsERC1167ProxySuccess`; `if (result)` -> `if (true)` -> `testIsERC1167ProxyEOFWithValidSuffix`. Full table above with per-mutant test counts.
- Oracle: EIP-1167 (`https://eips.ethereum.org/EIPS/eip-1167`) fixes the 45-byte layout and the `0x363d3d373d3d3d363d73` prefix; EIP-3540 fixes the EOF `0xEF00` magic. The two are disjoint by their first byte, so an EOF container is a non-proxy independently of this implementation. Each new test asserts its input is EOF via `LibExtrospectBytecode.isEOFBytecode` before asserting the non-proxy result, so the EOF-ness of the fixture is not assumed.
- Category check: issue #72 asks for (A) a NatSpec sentence and (B) a test, to settle whether the missing EOF gate is deliberate. Covered A and B. The third possibility the issue raises — actually adding the gate — changes what the library concludes about EOF bytecode and is deliberately NOT in this PR; the option space is posted on the issue for a human ruling.
