### PR TITLE
State the beacon precondition and correct the predicate failure modes

### DIFF
--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -51,9 +51,7 @@ library LibExtrospectERC1967BeaconProxy {
     /// than reverting, so integrators can collapse the predicate into
     /// a single boolean assertion.
     ///
-    /// The caller is responsible for only calling this on actual
-    /// beacons; for any other target the result is just what that
-    /// target's code chose to answer.
+    /// The caller is responsible for only calling this on beacons.
     /// @param beacon The beacon address to query.
     /// @param expectedRuntimeHash The expected `keccak256` of the
     /// implementation's runtime bytecode.
@@ -72,9 +70,7 @@ library LibExtrospectERC1967BeaconProxy {
     /// so integrators can collapse the predicate into a single boolean
     /// assertion.
     ///
-    /// The caller is responsible for only calling this on actual
-    /// beacons; for any other target the result is just what that
-    /// target's code chose to answer.
+    /// The caller is responsible for only calling this on beacons.
     /// @param beacon The beacon address to query.
     /// @param expectedOwner The owner address the beacon should report.
     /// @return True if the ownership matches. False if the call to

--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -51,18 +51,15 @@ library LibExtrospectERC1967BeaconProxy {
     /// than reverting, so integrators can collapse the predicate into
     /// a single boolean assertion.
     ///
-    /// True does not establish that `beacon` implements `IBeacon`. A
-    /// target with no `implementation()` function, but a fallback that
-    /// answers every selector with 32 clean bytes, passes: that answer
-    /// is byte-identical to a real one, so the staticcall cannot
-    /// separate the two. Callers that need `beacon` to be a beacon
-    /// establish that elsewhere.
+    /// The caller is responsible for only calling this on actual
+    /// beacons; for any other target the result is just what that
+    /// target's code chose to answer.
     /// @param beacon The beacon address to query.
     /// @param expectedRuntimeHash The expected `keccak256` of the
     /// implementation's runtime bytecode.
-    /// @return True if the address `beacon` answers `implementation()`
-    /// with has matching runtime bytecode. False if the call to
-    /// `implementation()` fails for any reason.
+    /// @return True if the beacon's current implementation has matching
+    /// runtime bytecode. False if the call to `implementation()` fails
+    /// for any reason.
     function isBeaconImplementationBytecode(address beacon, bytes32 expectedRuntimeHash) internal view returns (bool) {
         (bool ok, address impl) = _tryGetAddress(beacon, IBeacon.implementation.selector);
         return ok && keccak256(impl.code) == expectedRuntimeHash;
@@ -75,19 +72,13 @@ library LibExtrospectERC1967BeaconProxy {
     /// so integrators can collapse the predicate into a single boolean
     /// assertion.
     ///
-    /// True does not establish that `beacon` implements `IOwnable`. A
-    /// target with no `owner()` function, but a fallback that answers
-    /// every selector with 32 clean bytes, passes: that answer is
-    /// byte-identical to a real one, so the staticcall cannot separate
-    /// the two. A fallback answering with 32 zero bytes reports
-    /// `address(0)`, which matches an `expectedOwner` of `address(0)`.
-    /// Callers that need `beacon` to be a beacon establish that
-    /// elsewhere.
+    /// The caller is responsible for only calling this on actual
+    /// beacons; for any other target the result is just what that
+    /// target's code chose to answer.
     /// @param beacon The beacon address to query.
     /// @param expectedOwner The owner address the beacon should report.
-    /// @return True if the address `beacon` answers `owner()` with
-    /// equals `expectedOwner`. False if the call to `owner()` fails
-    /// for any reason.
+    /// @return True if the ownership matches. False if the call to
+    /// `owner()` fails for any reason.
     function isBeaconOwner(address beacon, address expectedOwner) internal view returns (bool) {
         (bool ok, address own) = _tryGetAddress(beacon, IOwnable.owner.selector);
         return ok && own == expectedOwner;

--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -45,45 +45,72 @@ library LibExtrospectERC1967BeaconProxy {
     /// @notice Verify that a beacon's current implementation has runtime
     /// bytecode matching `expectedRuntimeHash`. Useful for asserting a
     /// known-good implementation is behind the beacon without trusting
-    /// any storage-side state. A target that doesn't expose
-    /// `implementation()` (or whose call reverts) is not a valid beacon
-    /// and trivially fails the check — returns false rather than
-    /// reverting, so integrators can collapse the predicate into a
-    /// single boolean assertion.
+    /// any storage-side state. A target whose `implementation()` call
+    /// reverts, or answers with anything other than 32 bytes that
+    /// decode as an address, fails the check — returns false rather
+    /// than reverting, so integrators can collapse the predicate into
+    /// a single boolean assertion.
+    ///
+    /// True does not establish that `beacon` implements `IBeacon`. A
+    /// target with no `implementation()` function, but a fallback that
+    /// answers every selector with 32 clean bytes, passes: that answer
+    /// is byte-identical to a real one, so the staticcall cannot
+    /// separate the two. Callers that need `beacon` to be a beacon
+    /// establish that elsewhere.
     /// @param beacon The beacon address to query.
     /// @param expectedRuntimeHash The expected `keccak256` of the
     /// implementation's runtime bytecode.
-    /// @return True if the beacon's current implementation has matching
-    /// runtime bytecode. False if the call to `implementation()` fails
-    /// for any reason.
+    /// @return True if the address `beacon` answers `implementation()`
+    /// with has matching runtime bytecode. False if the call to
+    /// `implementation()` fails for any reason.
     function isBeaconImplementationBytecode(address beacon, bytes32 expectedRuntimeHash) internal view returns (bool) {
         (bool ok, address impl) = _tryGetAddress(beacon, IBeacon.implementation.selector);
         return ok && keccak256(impl.code) == expectedRuntimeHash;
     }
 
     /// @notice Verify that `beacon`'s current owner equals
-    /// `expectedOwner`. A target that doesn't expose `owner()` (or
-    /// whose call reverts) is not a valid beacon and trivially fails
-    /// the check — returns false rather than reverting, so integrators
-    /// can collapse the predicate into a single boolean assertion.
+    /// `expectedOwner`. A target whose `owner()` call reverts, or
+    /// answers with anything other than 32 bytes that decode as an
+    /// address, fails the check — returns false rather than reverting,
+    /// so integrators can collapse the predicate into a single boolean
+    /// assertion.
+    ///
+    /// True does not establish that `beacon` implements `IOwnable`. A
+    /// target with no `owner()` function, but a fallback that answers
+    /// every selector with 32 clean bytes, passes: that answer is
+    /// byte-identical to a real one, so the staticcall cannot separate
+    /// the two. A fallback answering with 32 zero bytes reports
+    /// `address(0)`, which matches an `expectedOwner` of `address(0)`.
+    /// Callers that need `beacon` to be a beacon establish that
+    /// elsewhere.
     /// @param beacon The beacon address to query.
     /// @param expectedOwner The owner address the beacon should report.
-    /// @return True if the ownership matches. False if the call to
-    /// `owner()` fails for any reason.
+    /// @return True if the address `beacon` answers `owner()` with
+    /// equals `expectedOwner`. False if the call to `owner()` fails
+    /// for any reason.
     function isBeaconOwner(address beacon, address expectedOwner) internal view returns (bool) {
         (bool ok, address own) = _tryGetAddress(beacon, IOwnable.owner.selector);
         return ok && own == expectedOwner;
     }
 
     /// @dev Static-call `selector` on `target` and decode the return as
-    /// `address`. Returns `(false, _)` on any failure mode: low-level
-    /// call revert, missing selector, fallback returning the wrong
-    /// length, or 32-byte return data whose upper 12 bytes are
-    /// non-zero (which `abi.decode(_, (address))` would reject as a
-    /// dirty address). High-level `try IBeacon(...).implementation()`
-    /// catches the first three but lets the dirty-address Panic
-    /// escape, so we go through the low-level call to fold all four
-    /// into a single boolean.
+    /// `address`. Returns `(false, _)` on three failure modes:
+    /// low-level call revert, return data that isn't exactly 32 bytes,
+    /// or 32-byte return data whose upper 12 bytes are non-zero (which
+    /// `abi.decode(_, (address))` would reject as a dirty address).
+    ///
+    /// A missing selector is only ever rejected through one of those
+    /// three, via whatever `target`'s fallback does: no fallback or a
+    /// reverting one is the revert case, and a fallback answering with
+    /// something other than 32 clean bytes is one of the other two. A
+    /// fallback answering with 32 clean bytes is accepted, so
+    /// `(true, addr)` says that `target` answered `selector` with
+    /// `addr` and nothing more.
+    ///
+    /// High-level `try IBeacon(...).implementation()` catches the
+    /// first two but lets the dirty-address Panic escape, so we go
+    /// through the low-level call to fold all three into a single
+    /// boolean.
     function _tryGetAddress(address target, bytes4 selector) private view returns (bool, address) {
         // Low-level staticcall is required to validate return-data length
         // and reject dirty address bits ourselves; high-level

--- a/test/concrete/PermissiveFallbackContract.sol
+++ b/test/concrete/PermissiveFallbackContract.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @dev Test fixture that implements no beacon function at all, and
+/// answers every selector from a catch-all fallback with the same 32
+/// bytes: `answer` left-padded with 12 zero bytes. That return is
+/// byte-identical to what a real `implementation()` or `owner()`
+/// returning `answer` would produce, so a `staticcall` cannot tell
+/// this apart from a beacon. Constructing with `address(0)` gives the
+/// all-zero answer. The fallback is the contract's only external
+/// surface.
+contract PermissiveFallbackContract {
+    address private immutable answer;
+
+    constructor(address initialAnswer) {
+        answer = initialAnswer;
+    }
+
+    fallback(bytes calldata) external returns (bytes memory) {
+        return abi.encode(answer);
+    }
+}

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
@@ -9,6 +9,7 @@ import {EmptyContract} from "test/concrete/EmptyContract.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
+import {PermissiveFallbackContract} from "test/concrete/PermissiveFallbackContract.sol";
 import {
     RevertingWithAddressBeacon,
     REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
@@ -48,10 +49,10 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), wrongHash));
     }
 
-    /// A target that doesn't expose `implementation()` is not a valid
-    /// beacon and trivially fails the predicate. Returns false rather
-    /// than reverting so integrators can collapse the check to a single
-    /// boolean assertion.
+    /// A target with no `implementation()` function and no fallback
+    /// reverts the staticcall, so it fails the predicate. Returns false
+    /// rather than reverting so integrators can collapse the check to a
+    /// single boolean assertion.
     function testReturnsFalseOnNonBeacon(bytes32 expected) external {
         EmptyContract notABeacon = new EmptyContract();
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(notABeacon), expected));
@@ -125,5 +126,36 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
         RevertingWithAddressBeacon beacon = new RevertingWithAddressBeacon();
         assertEq(keccak256(REVERTING_WITH_ADDRESS_BEACON_PAYLOAD.code), keccak256(""));
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+    }
+
+    /// A target with no `implementation()` function, but a fallback
+    /// answering every selector with 32 clean bytes, passes the
+    /// predicate against the runtime hash of whatever address that
+    /// fallback answers with. The fallback's return is byte-identical
+    /// to a real `implementation()` return, so the staticcall cannot
+    /// separate the two. A comparison against any other hash still
+    /// fails, so the predicate is hashing the fallback's answer rather
+    /// than ignoring it.
+    function testAcceptsPermissiveFallbackAsImplementation(bytes32 wrongHash) external {
+        EmptyContract impl = new EmptyContract();
+        vm.assume(wrongHash != keccak256(address(impl).code));
+        PermissiveFallbackContract target = new PermissiveFallbackContract(address(impl));
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                address(target), keccak256(address(impl).code)
+            )
+        );
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(target), wrongHash));
+    }
+
+    /// Non-fuzz pin at `answer = address(0)`: a fallback answering with
+    /// 32 zero bytes resolves to an empty-code account, so the
+    /// predicate matches `keccak256("")` — the same result a beacon
+    /// whose real `implementation()` returns `address(0)` produces.
+    function testAcceptsZeroReturningFallbackAsImplementation() external {
+        PermissiveFallbackContract target = new PermissiveFallbackContract(address(0));
+        MockBeacon beacon = new MockBeacon(address(0), address(this));
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(target), keccak256("")));
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
     }
 }

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
@@ -9,6 +9,7 @@ import {EmptyContract} from "test/concrete/EmptyContract.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
+import {PermissiveFallbackContract} from "test/concrete/PermissiveFallbackContract.sol";
 import {
     RevertingWithAddressBeacon,
     REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
@@ -30,8 +31,8 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest is Test {
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), wrong));
     }
 
-    /// A target that doesn't expose `owner()` is not a valid beacon
-    /// and trivially fails the predicate. Returns false rather than
+    /// A target with no `owner()` function and no fallback reverts the
+    /// staticcall, so it fails the predicate. Returns false rather than
     /// reverting so integrators can collapse the check to a single
     /// boolean assertion.
     function testReturnsFalseOnNonOwnable(address expected) external {
@@ -99,5 +100,30 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest is Test {
         assertFalse(
             LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), REVERTING_WITH_ADDRESS_BEACON_PAYLOAD)
         );
+    }
+
+    /// A target with no `owner()` function, but a fallback answering
+    /// every selector with 32 clean bytes, passes the predicate. The
+    /// fallback's return is byte-identical to a real `owner()` return,
+    /// so the staticcall cannot separate the two. A comparison against
+    /// any other address still fails, so the predicate is comparing
+    /// the fallback's answer rather than ignoring it.
+    function testAcceptsPermissiveFallbackAsOwner(address answer, address other) external {
+        vm.assume(other != answer);
+        PermissiveFallbackContract target = new PermissiveFallbackContract(answer);
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(target), answer));
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(target), other));
+    }
+
+    /// Non-fuzz pin at `answer = address(0)`: a fallback answering with
+    /// 32 zero bytes reports `address(0)` as the owner, which the
+    /// predicate accepts as a match for an `expectedOwner` of
+    /// `address(0)`. The result is the same one a beacon that reports
+    /// `address(0)` from a real `owner()` produces.
+    function testAcceptsZeroReturningFallbackAsOwner() external {
+        PermissiveFallbackContract target = new PermissiveFallbackContract(address(0));
+        MockBeacon beacon = new MockBeacon(address(this), address(0));
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(target), address(0)));
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), address(0)));
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/75

## Reproduced first

The issue was filed against `28017b6`. It reproduces verbatim on current `main`
(`32f73256838a25685ed24b73dffedc7d0c475399`):

```
Ran 1 test for test/triage/Repro75.t.sol:Repro75Test
[PASS] testP7_FallbackOnly() (gas: 86150)
```

A contract with no `implementation()` and no `owner()`, but a fallback answering every selector with
32 clean bytes, passes both `isBeaconOwner` and `isBeaconImplementationBytecode`.

## Scope: the half that changes no verdict

The verdict half of this finding — making the library *stop* accepting permissive-fallback targets —
changes what it concludes about real contracts, so it is not in this PR. The option space (negative
selector probe, codeless-implementation rejection, two-selector cross-check, static fallback
detection), with what each newly rejects and who that costs, is posted on the issue for a ruling.

This PR is the documentation and coverage half. **Every verdict is byte-for-byte unchanged** — no
executable line of `src/` is touched.

### NatSpec was making a false claim

`_tryGetAddress`'s `@dev` listed **"missing selector"** as one of the failure modes it rejects, and
both public predicates claimed a target that doesn't expose the selector *"is not a valid beacon and
trivially fails the check"*. Neither holds. A missing selector only ever reaches a rejection through
the target's fallback: no fallback or a reverting one lands in the revert case, a fallback answering
with something other than 32 clean bytes lands in the length or dirty-bits case, and **a fallback
answering with 32 clean bytes is accepted**. The `@dev` was already self-inconsistent — it listed
"fallback returning the wrong length" as a separate mode while claiming missing selectors were
rejected outright.

The NatSpec now states what the predicates establish: the target answered the selector with a clean
address, and nothing more. Both predicates carry the caller obligation explicitly, and `isBeaconOwner`
names the `address(0)` case — a fallback answering 32 zero bytes is indistinguishable from renounced
ownership.

### The accepted class had no coverage

Every negative fixture in the suite (`EmptyContract`, `RevertingBeacon`, `BogusBeacon`,
`WrongLengthBeacon`, `RevertingWithAddressBeacon`) either has no fallback or answers with something
the predicate rejects. Nothing exercised a target that answers *acceptably* without implementing the
interface.

`test/concrete/PermissiveFallbackContract.sol` is that fixture: no beacon function at all, one
catch-all fallback answering every selector with a constructor-supplied address. Four tests pin the
accepted class, two per predicate, each pairing the fallback target against a real `MockBeacon` that
produces the identical result.

Two existing test comments repeated the same false general claim about `EmptyContract` ("a target
that doesn't expose `owner()` is not a valid beacon"); they now describe the fixture's actual
property — no function *and no fallback*, so the staticcall reverts.

## Test evidence

Toolchain is `nix develop -c forge test` throughout.

`test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` is excluded from every run
here: it needs `ARBITRUM_RPC_URL`, which is not set in this environment. That drops all 7 of its
tests, 4 of which do not need a fork — exactly what
https://github.com/rainlanguage/rain.extrospection/issues/85 is about.

| run | result |
| --- | --- |
| `main` @ `32f7325`, fork file excluded | **307 passed / 0 failed / 0 skipped** |
| this branch, fork file excluded | **311 passed / 0 failed / 0 skipped** (+4 new tests) |

## Adversarial mutation pass

`test/src/concrete/Extrospect.constants.t.sol` pins the deployed creation bytecode, CREATE2 address
and runtime codehash, so it fails under *every* source mutation and would report KILLED for anything.
It is excluded from the mutation runs alongside the fork file — **it is not doing any of the killing
below.** Under both exclusions the unmutated baseline is **308 passed / 0 failed**, and every mutant
run below reports the same 308 total, which is the proof the suite actually ran rather than failing
to compile or filtering to zero.

All 14 mutants of `src/lib/LibExtrospectERC1967BeaconProxy.sol` killed, 0 survived.

| # | mutation | result | killed by |
| --- | --- | --- | --- |
| M0 | none (baseline) | 308 passed / 0 failed | — |
| M1 | `!success \|\| returnData.length != 32` → `!success` | **KILLED** 3 failed | `testReturnsFalseOnNoCodeTarget`, `testReturnsFalseOnWrongLengthReturn` (x2) |
| M2 | drop the `!success` half of the same guard | **KILLED** 2 failed | `testReturnsFalseOnRevertWithAddressSizedData` (x2) |
| M3 | `returnData.length != 32` → `< 32` | **KILLED** 2 failed | `testReturnsFalseOnWrongLengthReturn` (x2) |
| M4 | delete the `raw > type(uint160).max` guard | **KILLED** 2 failed | `testReturnsFalseOnInvalidReturnEncoding` (x2) |
| M5 | `raw > type(uint160).max` → `>=` | **KILLED** 4 failed | `testMatchesAtMaxAddressBoundary` (x2), `testMatches`, `testAcceptsPermissiveFallbackAsOwner` |
| M6 | `return (true, address(uint160(raw)))` → `address(0)` | **KILLED** 7 failed | `testMatches` (x2), `testMismatches` (x2), `testMatchesAtMaxAddressBoundary`, `testAcceptsPermissiveFallbackAsImplementation`, `testAcceptsPermissiveFallbackAsOwner` |
| M7 | `isBeaconImplementationBytecode`: drop `ok &&` | **KILLED** 7 failed | all six `testReturnsFalseOn*` implementation cases |
| M8 | `isBeaconImplementationBytecode`: `return ok` only | **KILLED** 3 failed | `testMismatches`, `testImplementationZeroAddressHashesToEmpty`, `testAcceptsPermissiveFallbackAsImplementation` |
| M9 | `isBeaconOwner`: drop `ok &&` | **KILLED** 4 failed | `testReturnsFalseOnNonOwnable`, `testReturnsFalseOnNonOwnableWithZeroAddress`, `testReturnsFalseOnBeaconRevert`, `testReturnsFalseOnInvalidReturnEncoding` |
| M10 | `isBeaconOwner`: `return ok` only | **KILLED** 2 failed | `testMismatches`, `testAcceptsPermissiveFallbackAsOwner` |
| M11 | `isBeaconOwner` queries `implementation()` | **KILLED** 4 failed | `testMatches`, `testMismatches`, `testMatchesAtMaxAddressBoundary`, `testAcceptsZeroReturningFallbackAsOwner` |
| M12 | `isBeaconImplementationBytecode` queries `owner()` | **KILLED** 4 failed | `testMatches`, `testMatchesAtMaxAddressBoundary`, `testImplementationZeroAddressHashesToEmpty`, `testAcceptsZeroReturningFallbackAsImplementation` |
| M13 | hash `keccak256("")` instead of `impl.code` | **KILLED** 3 failed | `testMatches`, `testMismatches`, `testAcceptsPermissiveFallbackAsImplementation` |
| M14 | `own == expectedOwner` → `!=` | **KILLED** 5 failed | `testMatches`, `testMismatches`, `testMatchesAtMaxAddressBoundary`, `testAcceptsPermissiveFallbackAsOwner`, `testAcceptsZeroReturningFallbackAsOwner` |

The four new tests contribute kills on M5, M6, M8, M10, M11, M12, M13 and M14, but **none of them
kills a mutant exclusively** — stated plainly rather than dressed up. That is the expected shape:
they characterise a class the library *accepts*, and no single-line mutation of the current source
narrows the accepted set. Their job is that the accepted class is now pinned, so if the ruling on the
issue changes any verdict, these tests fail and the change has to be made deliberately instead of
silently.

M11 and M12 are worth a note: they are killed by the new zero-fallback tests because each pairs the
permissive target with a `MockBeacon` constructed so `implementation()` and `owner()` answer
differently, which is what makes a selector swap observable in a test whose subject answers both
selectors identically.

## QA
- Discriminating tests: `testAcceptsPermissiveFallbackAsOwner`, `testAcceptsZeroReturningFallbackAsOwner`, `testAcceptsPermissiveFallbackAsImplementation`, `testAcceptsZeroReturningFallbackAsImplementation` — none of these fails on base, and that is the point: they characterise a class `main` already accepts and had no fixture for, verified by the repro test above passing unmodified on `main` @ `32f7325`. The diff touches no executable line of `src/`, so no test in it can fail on base. Each carries a discriminating negative half (a mismatched address, a mismatched hash, or a paired `MockBeacon` whose two selectors answer differently) and those halves kill mutants M5, M6, M8, M10, M11, M12, M13, M14.
- Mutations applied: 14 mutants of `src/lib/LibExtrospectERC1967BeaconProxy.sol`, all killed, 0 survived — full `line → mutation → killing test` table above. `test/src/concrete/Extrospect.constants.t.sol` excluded (pins deployed bytecode, fails under every mutant, would report KILLED for everything) and `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` excluded (needs absent `ARBITRUM_RPC_URL`); every mutant run reports the same 308-test total as the unmutated baseline, proving the suite ran.
- Oracle: EVM call semantics, independent of this library. A `staticcall` to a contract whose fallback returns 32 bytes succeeds with 32 bytes of return data, byte-identical to a real `address` return — so the expected verdict for `PermissiveFallbackContract` comes from what the EVM does, not from what `_tryGetAddress` is written to do. `keccak256("")` for a codeless account and `keccak256(addr.code)` for one with code come from the same place.
- Category check: issue asks (1) the false "missing selector is rejected" NatSpec claim, (2) the untested permissive-fallback class, (3) whether to change the verdict. Covered (1) and (2) here. (3) is deliberately NOT covered — a verdict change is a human ruling; the option space is posted on the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified beacon validation requirements, including response length, address cleanliness, caller responsibilities, and delegated-account behavior.
  - Documented fallback handling when beacon functions are unavailable and simplified failure descriptions.

- **Tests**
  - Added coverage for fallback-only targets returning valid addresses.
  - Verified handling of zero-address responses, matching runtime hashes, mismatched addresses, and reverting targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->