### PR TITLE
Beacon predicates report the beacon's answer to msg.sender, not a property of the beacon

### DIFF
--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -23,10 +23,13 @@ bytes32 constant ERC1967_BEACON_SLOT = bytes32(uint256(keccak256("eip1967.proxy.
 ///
 /// What's possible from a runtime contract context (no cheat codes):
 ///
-/// - Read a beacon's implementation via `IBeacon.implementation()` —
-///   well-defined interface, callable from anywhere.
-/// - Read a beacon's owner via `Ownable.owner()` — de-facto convention
-///   for beacons that inherit OZ `Ownable` or equivalent.
+/// - Read what a beacon answers to `IBeacon.implementation()` —
+///   well-defined interface, callable from anywhere. It is an ordinary
+///   function rather than a storage read, so the answer is the beacon's
+///   own and may be keyed off `msg.sender`.
+/// - Read what a beacon answers to `Ownable.owner()` — de-facto
+///   convention for beacons that inherit OZ `Ownable` or equivalent.
+///   Also an ordinary function, with the same caller sensitivity.
 /// - Hash a contract's runtime bytecode via `keccak256(addr.code)` to
 ///   compare against an expected template.
 ///
@@ -42,34 +45,47 @@ bytes32 constant ERC1967_BEACON_SLOT = bytes32(uint256(keccak256("eip1967.proxy.
 /// The slot constants are exported so callers that have storage access
 /// elsewhere use a single canonical source for the slot addresses.
 library LibExtrospectERC1967BeaconProxy {
-    /// @notice Verify that a beacon's current implementation has runtime
-    /// bytecode matching `expectedRuntimeHash`. Useful for asserting a
-    /// known-good implementation is behind the beacon without trusting
-    /// any storage-side state. A target that doesn't expose
-    /// `implementation()` (or whose call reverts) is not a valid beacon
-    /// and trivially fails the check — returns false rather than
+    /// @notice Report whether the address `beacon` returns from
+    /// `implementation()` to `msg.sender` has runtime bytecode matching
+    /// `expectedRuntimeHash`. The answer is the beacon's, not a storage
+    /// slot this library reads, so the result holds for the calling
+    /// contract only: a beacon that keys `implementation()` off
+    /// `msg.sender` returns true here and serves a different
+    /// implementation to the proxies it fronts, in the same
+    /// transaction. `Extrospect` calls the beacon as itself, so its
+    /// answer and this library's answer, invoked from a different
+    /// contract, can differ for the same beacon. A target that doesn't
+    /// expose `implementation()` (or whose call reverts) is not a valid
+    /// beacon and trivially fails the check — returns false rather than
     /// reverting, so integrators can collapse the predicate into a
     /// single boolean assertion.
     /// @param beacon The beacon address to query.
     /// @param expectedRuntimeHash The expected `keccak256` of the
     /// implementation's runtime bytecode.
-    /// @return True if the beacon's current implementation has matching
-    /// runtime bytecode. False if the call to `implementation()` fails
-    /// for any reason.
+    /// @return True if the implementation the beacon returns to
+    /// `msg.sender` has matching runtime bytecode. False if the call to
+    /// `implementation()` fails for any reason.
     function isBeaconImplementationBytecode(address beacon, bytes32 expectedRuntimeHash) internal view returns (bool) {
         (bool ok, address impl) = _tryGetAddress(beacon, IBeacon.implementation.selector);
         return ok && keccak256(impl.code) == expectedRuntimeHash;
     }
 
-    /// @notice Verify that `beacon`'s current owner equals
-    /// `expectedOwner`. A target that doesn't expose `owner()` (or
-    /// whose call reverts) is not a valid beacon and trivially fails
-    /// the check — returns false rather than reverting, so integrators
-    /// can collapse the predicate into a single boolean assertion.
+    /// @notice Report whether the address `beacon` returns from
+    /// `owner()` to `msg.sender` equals `expectedOwner`. The answer is
+    /// the beacon's, not a storage slot this library reads, so the
+    /// result holds for the calling contract only: a beacon that keys
+    /// `owner()` off `msg.sender` returns true here while reporting a
+    /// different owner to everyone else. `Extrospect` calls the beacon
+    /// as itself, so its answer and this library's answer, invoked from
+    /// a different contract, can differ for the same beacon. A target
+    /// that doesn't expose `owner()` (or whose call reverts) is not a
+    /// valid beacon and trivially fails the check — returns false
+    /// rather than reverting, so integrators can collapse the predicate
+    /// into a single boolean assertion.
     /// @param beacon The beacon address to query.
     /// @param expectedOwner The owner address the beacon should report.
-    /// @return True if the ownership matches. False if the call to
-    /// `owner()` fails for any reason.
+    /// @return True if the owner the beacon reports to `msg.sender`
+    /// matches. False if the call to `owner()` fails for any reason.
     function isBeaconOwner(address beacon, address expectedOwner) internal view returns (bool) {
         (bool ok, address own) = _tryGetAddress(beacon, IOwnable.owner.selector);
         return ok && own == expectedOwner;

--- a/test/concrete/CallerKeyedBeacon.sol
+++ b/test/concrete/CallerKeyedBeacon.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IBeacon} from "src/interface/IBeacon.sol";
+import {IOwnable} from "src/interface/IOwnable.sol";
+
+/// @dev Beacon test fixture that keys its answer off `msg.sender`.
+/// `singledOut` gets `singledOutAnswer` from both `implementation()`
+/// and `owner()`; every other caller gets `defaultAnswer`. Both
+/// selectors share one pair of answers because the predicates under
+/// test read one address each.
+contract CallerKeyedBeacon is IBeacon, IOwnable {
+    address public immutable singledOut;
+    address public immutable defaultAnswer;
+    address public immutable singledOutAnswer;
+
+    constructor(address singledOut_, address defaultAnswer_, address singledOutAnswer_) {
+        singledOut = singledOut_;
+        defaultAnswer = defaultAnswer_;
+        singledOutAnswer = singledOutAnswer_;
+    }
+
+    function implementation() external view returns (address) {
+        return msg.sender == singledOut ? singledOutAnswer : defaultAnswer;
+    }
+
+    function owner() external view returns (address) {
+        return msg.sender == singledOut ? singledOutAnswer : defaultAnswer;
+    }
+}

--- a/test/src/concrete/Extrospect.isBeaconImplementationBytecode.t.sol
+++ b/test/src/concrete/Extrospect.isBeaconImplementationBytecode.t.sol
@@ -6,6 +6,7 @@ import {ExtrospectEquivalence} from "test/concrete/ExtrospectEquivalence.sol";
 import {LibExtrospectERC1967BeaconProxy} from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
 import {MockBeacon} from "test/concrete/MockBeacon.sol";
 import {EmptyContract} from "test/concrete/EmptyContract.sol";
+import {CallerKeyedBeacon} from "test/concrete/CallerKeyedBeacon.sol";
 
 contract ExtrospectIsBeaconImplementationBytecodeTest is ExtrospectEquivalence {
     function testIsBeaconImplementationBytecodeEquivalenceMatch() external {
@@ -28,5 +29,20 @@ contract ExtrospectIsBeaconImplementationBytecodeTest is ExtrospectEquivalence {
             extrospect.isBeaconImplementationBytecode(address(beacon), wrong),
             LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), wrong)
         );
+    }
+
+    /// The concrete instance queries the beacon as itself; the library
+    /// queries it as whichever contract invoked the library. Against a
+    /// beacon that keys `implementation()` off its caller and singles
+    /// out the `Extrospect` instance, the two return opposite answers
+    /// for the same beacon and the same expected hash.
+    function testIsBeaconImplementationBytecodeDivergesOnCallerKeyedBeacon() external {
+        EmptyContract impl = new EmptyContract();
+        CallerKeyedBeacon beacon = new CallerKeyedBeacon(address(extrospect), address(impl), address(0));
+        bytes32 expected = keccak256(address(impl).code);
+        assertTrue(expected != keccak256(""));
+
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), expected));
+        assertFalse(extrospect.isBeaconImplementationBytecode(address(beacon), expected));
     }
 }

--- a/test/src/concrete/Extrospect.isBeaconOwner.t.sol
+++ b/test/src/concrete/Extrospect.isBeaconOwner.t.sol
@@ -6,6 +6,7 @@ import {ExtrospectEquivalence} from "test/concrete/ExtrospectEquivalence.sol";
 import {LibExtrospectERC1967BeaconProxy} from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
 import {MockBeacon} from "test/concrete/MockBeacon.sol";
 import {EmptyContract} from "test/concrete/EmptyContract.sol";
+import {CallerKeyedBeacon} from "test/concrete/CallerKeyedBeacon.sol";
 
 contract ExtrospectIsBeaconOwnerTest is ExtrospectEquivalence {
     function testIsBeaconOwnerEquivalenceMatch(address owner) external {
@@ -27,5 +28,19 @@ contract ExtrospectIsBeaconOwnerTest is ExtrospectEquivalence {
             extrospect.isBeaconOwner(address(beacon), wrong),
             LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), wrong)
         );
+    }
+
+    /// The concrete instance queries the beacon as itself; the library
+    /// queries it as whichever contract invoked the library. Against a
+    /// beacon that keys `owner()` off its caller and singles out the
+    /// `Extrospect` instance, the two return opposite answers for the
+    /// same beacon and the same expected owner.
+    function testIsBeaconOwnerDivergesOnCallerKeyedBeacon() external {
+        address defaultOwner = address(uint160(0xA11CE));
+        address singledOutOwner = address(uint160(0xBAD));
+        CallerKeyedBeacon beacon = new CallerKeyedBeacon(address(extrospect), defaultOwner, singledOutOwner);
+
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), defaultOwner));
+        assertFalse(extrospect.isBeaconOwner(address(beacon), defaultOwner));
     }
 }

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibExtrospectERC1967BeaconProxy} from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
 import {MockBeacon} from "test/concrete/MockBeacon.sol";
 import {EmptyContract} from "test/concrete/EmptyContract.sol";
+import {CallerKeyedBeacon} from "test/concrete/CallerKeyedBeacon.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
@@ -125,5 +126,26 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
         RevertingWithAddressBeacon beacon = new RevertingWithAddressBeacon();
         assertEq(keccak256(REVERTING_WITH_ADDRESS_BEACON_PAYLOAD.code), keccak256(""));
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+    }
+
+    /// The predicate reports the implementation the beacon returns to
+    /// `msg.sender`. A beacon that keys `implementation()` off its
+    /// caller flips the predicate for the caller it singles out, with
+    /// no state change between the two calls.
+    function testImplementationIsTheBeaconAnswerToTheCaller() external {
+        EmptyContract impl = new EmptyContract();
+        address singledOut = address(uint160(0xBEEF));
+        CallerKeyedBeacon beacon = new CallerKeyedBeacon(singledOut, address(impl), address(0));
+        bytes32 defaultHash = keccak256(address(impl).code);
+        bytes32 singledOutHash = keccak256("");
+        assertTrue(defaultHash != singledOutHash);
+
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), defaultHash));
+
+        vm.prank(singledOut);
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), defaultHash));
+
+        vm.prank(singledOut);
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), singledOutHash));
     }
 }

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibExtrospectERC1967BeaconProxy} from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
 import {MockBeacon} from "test/concrete/MockBeacon.sol";
 import {EmptyContract} from "test/concrete/EmptyContract.sol";
+import {CallerKeyedBeacon} from "test/concrete/CallerKeyedBeacon.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
@@ -99,5 +100,24 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest is Test {
         assertFalse(
             LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), REVERTING_WITH_ADDRESS_BEACON_PAYLOAD)
         );
+    }
+
+    /// The predicate reports the owner the beacon returns to
+    /// `msg.sender`. A beacon that keys `owner()` off its caller flips
+    /// the predicate for the caller it singles out, with no state
+    /// change between the two calls.
+    function testOwnerIsTheBeaconAnswerToTheCaller() external {
+        address singledOut = address(uint160(0xBEEF));
+        address defaultOwner = address(uint160(0xA11CE));
+        address singledOutOwner = address(uint160(0xBAD));
+        CallerKeyedBeacon beacon = new CallerKeyedBeacon(singledOut, defaultOwner, singledOutOwner);
+
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), defaultOwner));
+
+        vm.prank(singledOut);
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), defaultOwner));
+
+        vm.prank(singledOut);
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), singledOutOwner));
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/76

## Finding, reproduced on `main` (`32f7325`)

`isBeaconImplementationBytecode` and `isBeaconOwner` reach the beacon through
`_tryGetAddress`, which `staticcall`s `implementation()` / `owner()`. Those are
ordinary functions, not storage reads, so what comes back is whatever the beacon
chooses to return **to `msg.sender`**. The NatSpec claimed the opposite —
"asserting a known-good implementation is behind the beacon without trusting any
storage-side state" — while the predicate trusts the beacon's self-report and
nothing else.

Two consequences, both reproduced against unmodified `main` before any change:

1. A beacon that returns the vetted implementation to everyone except the proxy
   it actually fronts satisfies the predicate atomically, in the same
   transaction, while the proxy delegatecalls something else. The audit's
   "Beacon Mutability" mitigation (single atomic transaction) does not reach
   this — there is no state change between the two answers.
2. `Extrospect` calls the beacon as itself; the library calls it as whichever
   contract invoked the library. Against such a beacon the concrete contract and
   the library return **opposite** answers for the same beacon and the same
   expected value. `test/concrete/ExtrospectEquivalence.sol` asserts
   concrete == library as an invariant everywhere else, and nothing tested these
   two functions against a caller-keyed beacon.

## What this PR does

Documentation and tests. **No verdict changes** — the predicate bodies are
untouched, so every input the library accepted it still accepts and every input
it rejected it still rejects. `test/src/concrete/Extrospect.constants.t.sol`
pins `type(Extrospect).creationCode` byte-for-byte and passes unchanged on this
branch, which is the proof: identical deployed bytecode, identical verdicts.

- `src/lib/LibExtrospectERC1967BeaconProxy.sol` — the "without trusting any
  storage-side state" claim is gone. Both predicates now state what they report:
  the address the beacon returns to `msg.sender`, with `Extrospect`'s answer and
  the library's answer able to differ for the same beacon because `Extrospect`
  calls as itself. The library-level "what's possible" block now says
  `implementation()` and `owner()` are ordinary functions whose answers may be
  keyed off the caller.
- `test/concrete/CallerKeyedBeacon.sol` — new fixture. One singled-out caller
  gets a different answer from `implementation()` and `owner()` than everyone
  else.
- Four new tests:

| test | file | pins |
| --- | --- | --- |
| `testImplementationIsTheBeaconAnswerToTheCaller` | `test/src/lib/…isBeaconImplementationBytecode.t.sol` | same beacon, same expected hash, opposite results for two callers, no state change between them |
| `testOwnerIsTheBeaconAnswerToTheCaller` | `test/src/lib/…isBeaconOwner.t.sol` | the same for `owner()` |
| `testIsBeaconImplementationBytecodeDivergesOnCallerKeyedBeacon` | `test/src/concrete/Extrospect.isBeaconImplementationBytecode.t.sol` | concrete returns false where the library returns true |
| `testIsBeaconOwnerDivergesOnCallerKeyedBeacon` | `test/src/concrete/Extrospect.isBeaconOwner.t.sol` | the same for `owner()` |

## Deliberately not done

Nothing here narrows or widens what the library concludes. Making the verdict
caller-independent is not possible inside the library — a `staticcall` cannot
ask a beacon what it would answer someone else — and every approach that would
close the hole (rejecting beacons whose bytecode reaches `CALLER`, requiring the
beacon's own bytecode to be pinned, per-selector reachability, removing the
predicates) changes what the library concludes about real contracts and, for
most of them, redeploys `Extrospect` at a new deterministic address. The full
option space, with what each one newly rejects and who it breaks, is posted on
issue #76 for a human to rule on.

## Test runs

Toolchain: `nix develop -c forge test`. Two exclusions, both stated:
`test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` needs
`ARBITRUM_RPC_URL`, absent in this environment (7 tests lost — issue #85), and
for the mutation pass only, `test/src/concrete/Extrospect.constants.t.sol`,
which pins deployed bytecode and therefore fails under every source mutation, so
including it would report KILLED for every mutant and measure nothing.

| run | result |
| --- | --- |
| `main`, RPC file excluded | 26 suites, **307 passed, 0 failed, 0 skipped** |
| this branch, RPC file excluded (constants test included and passing) | 26 suites, **311 passed, 0 failed, 0 skipped** |
| this branch, mutation baseline (RPC file + constants test excluded) | 25 suites, **308 passed, 0 failed, 0 skipped** |

## Adversarial mutation pass

14 mutants over the two files this PR touches the tests of, run with
`nix develop -c forge test --no-match-path '{test/src/concrete/Extrospect.constants.t.sol,test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol}'`.
**Every run reported `308 total tests`, the same count as the mutation baseline**
— proof the suite actually ran each time and no run is a zero-match filter
faking a SURVIVED. **14 killed, 0 survived.**

| # | line | mutation | result | killed by |
| --- | --- | --- | --- | --- |
| M1 | `LibExtrospectERC1967BeaconProxy.sol:70` | `return ok && keccak256(impl.code) == …` → drop `ok &&` | KILLED (7) | `testReturnsFalseOnNonBeacon`, `testReturnsFalseOnNonBeaconWithEmptyHash`, `testReturnsFalseOnBeaconRevert`, `testReturnsFalseOnInvalidReturnEncoding`, `testReturnsFalseOnNoCodeTarget`, `testReturnsFalseOnWrongLengthReturn`, `testReturnsFalseOnRevertWithAddressSizedData` |
| M2 | `:91` | `return ok && own == expectedOwner;` → drop `ok &&` | KILLED (4) | `testReturnsFalseOnNonOwnable`, `testReturnsFalseOnNonOwnableWithZeroAddress`, `testReturnsFalseOnBeaconRevert`, `testReturnsFalseOnInvalidReturnEncoding` |
| M3 | `:110` | `if (!success \|\| returnData.length != 32)` → `if (!success)` | KILLED (3) | `testReturnsFalseOnWrongLengthReturn` (both suites), `testReturnsFalseOnNoCodeTarget` |
| M4 | `:110` | same line → `if (returnData.length != 32)` | KILLED (2) | `testReturnsFalseOnRevertWithAddressSizedData` (both suites) |
| M5 | `:115` | delete the `raw > type(uint160).max` guard | KILLED (2) | `testReturnsFalseOnInvalidReturnEncoding` (both suites) |
| M6 | `:115` | `raw > type(uint160).max` → `raw >= …` | KILLED (3) | `testMatchesAtMaxAddressBoundary` (both suites), `testMatches` |
| M7 | `:110` | `returnData.length != 32` → `< 32` | KILLED (2) | `testReturnsFalseOnWrongLengthReturn` (both suites) |
| M8 | `:69` | `IBeacon.implementation.selector` → `IOwnable.owner.selector` | KILLED (3) | `testMatches`, `testMatchesAtMaxAddressBoundary`, `testImplementationZeroAddressHashesToEmpty` |
| M9 | `:90` | `IOwnable.owner.selector` → `IBeacon.implementation.selector` | KILLED (3) | `testMatches`, `testMismatches`, `testMatchesAtMaxAddressBoundary` |
| M10 | `:70` | `keccak256(impl.code)` → `keccak256(beacon.code)` | KILLED (5) | `testMatches`, `testMatchesAtMaxAddressBoundary`, `testImplementationZeroAddressHashesToEmpty`, **`testImplementationIsTheBeaconAnswerToTheCaller`**, **`testIsBeaconImplementationBytecodeDivergesOnCallerKeyedBeacon`** |
| M11 | `:116` | `return (true, address(uint160(raw)));` → `return (true, address(0));` | KILLED (9) | `testMatches`, `testMismatches`, `testMatchesAtMaxAddressBoundary` (both suites), **all four new tests** |
| M12 | `:113` | `raw := mload(add(returnData, 0x20))` → `mload(returnData)` (reads the length word) | KILLED (10) | as M11 plus `testReturnsFalseOnInvalidReturnEncoding` |
| M13 | `Extrospect.sol:60` | `isBeaconImplementationBytecode` body → `return true;` | KILLED (2) | `testIsBeaconImplementationBytecodeEquivalenceMismatch`, **`testIsBeaconImplementationBytecodeDivergesOnCallerKeyedBeacon`** |
| M14 | `Extrospect.sol:65` | `isBeaconOwner` body → `return true;` | KILLED (2) | `testIsBeaconOwnerEquivalenceMismatch`, **`testIsBeaconOwnerDivergesOnCallerKeyedBeacon`** |

Bold entries are the tests this PR adds. Stated plainly: **none of the four is a
unique killer** — every mutant they catch was already caught by an existing test.
That is expected and is not a reason to drop them. The property they pin is not
produced by any line of source in this repo, so no source mutant can flip it: it
comes from `msg.sender` reaching the beacon, which is EVM call semantics. They
exist to hold the documented behaviour in place and to record, executably, the
one place where the `ExtrospectEquivalence` concrete == library invariant does
not hold.

## QA
- Discriminating tests: `testImplementationIsTheBeaconAnswerToTheCaller`,
  `testOwnerIsTheBeaconAnswerToTheCaller`,
  `testIsBeaconImplementationBytecodeDivergesOnCallerKeyedBeacon`,
  `testIsBeaconOwnerDivergesOnCallerKeyedBeacon` — **none fails on base, and
  cannot**: the source diff is comments only, so these run against byte-identical
  bytecode on base and on this branch (verified — `Extrospect.constants.t.sol`
  passes on the branch, pinning `type(Extrospect).creationCode` unchanged). They
  are characterisation tests: the behaviour they pin is the finding, and the
  finding is not a bug in a line of source but a consequence of `msg.sender`
  reaching the beacon. What they discriminate against is any future
  implementation that made the verdict caller-independent, and against the
  concrete == library invariant `ExtrospectEquivalence` asserts everywhere else,
  which these two functions violate. The finding itself was confirmed by
  standalone repro tests dropped into a clean clone of unmodified `main` and run
  there before any change was written, rather than taken on trust from the issue.
- Mutations applied: see the mutation table above — 14 mutants across
  `src/lib/LibExtrospectERC1967BeaconProxy.sol` and `src/concrete/Extrospect.sol`,
  each line → mutation → killing tests, 14/14 killed, 0 survived. Every run
  reports `308 total tests`, the same count as the mutation baseline, so no run
  is a zero-match filter reporting a false SURVIVED.
- Oracle: the beacon fixture's own constructor arguments — which address it hands
  to which caller — plus EVM call semantics (`msg.sender` at the beacon is the
  immediate caller, which for a library call is the calling contract and for
  `Extrospect` is `address(extrospect)`). Expected hashes are
  `keccak256(address(impl).code)` and `keccak256("")`, computed in the test from
  the fixture, never read back from the predicate under test.
- Category check: the issue asks for (A) the NatSpec correction dropping or
  qualifying "without trusting any storage-side state" and stating that the
  verdict is the beacon's answer to `msg.sender`, and (B) a test for the
  concrete-vs-library divergence. Covered A and B. The issue names
  `isBeaconImplementationBytecode` and says `isBeaconOwner` is "the same
  mechanism", so both predicates are covered on both counts rather than only the
  named one. Not covered, by design: any change to what the library concludes —
  posted as an option space on the issue instead.
