### PR TITLE
Document that OZ v5 BeaconProxy carries its beacon in runtime bytecode

### DIFF
--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -39,6 +39,14 @@ bytes32 constant ERC1967_BEACON_SLOT = bytes32(uint256(keccak256("eip1967.proxy.
 ///   `eth_getStorageAt`, or `sload` from a delegatecall context running
 ///   as the proxy.
 ///
+/// The slot is not the only place a proxy holds its beacon. OpenZeppelin
+/// v5 `BeaconProxy` also holds it in `address private immutable _beacon`,
+/// which solc inlines into the proxy's runtime bytecode, so `proxy.code`
+/// carries the 20 address bytes and any contract can read them.
+/// OpenZeppelin v4 `BeaconProxy` has no such immutable, so its runtime
+/// bytecode does not carry the address. This library extracts a beacon
+/// address from neither.
+///
 /// The slot constants are exported so callers that have storage access
 /// elsewhere use a single canonical source for the slot addresses.
 library LibExtrospectERC1967BeaconProxy {


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/80

## What was wrong

`src/lib/LibExtrospectERC1967BeaconProxy.sol` file-level NatSpec listed, under **"What's NOT possible from a
runtime contract context"**, reading a proxy's ERC-1967 beacon storage slot. That is true of the *slot* and
false as a reader will use it: OpenZeppelin v5 `BeaconProxy` holds the beacon in
`address private immutable _beacon`, which solc inlines into the proxy's **runtime bytecode**, so any
contract can read the 20 address bytes out of `proxy.code` — the same technique
`LibExtrospectERC1167Proxy` already implements in this repo for clones.

## Verification, not assumption

OZ v5 source (`OpenZeppelin/openzeppelin-contracts@v5.4.0`, header "last updated v5.2.0"):

```solidity
contract BeaconProxy is Proxy {
    // An immutable address for the beacon to avoid unnecessary SLOADs before each delegate call.
    address private immutable _beacon;
```

OZ is not a dependency of this repo, so rather than adding one I reproduced both shapes directly and ran
them. Repro dropped at `test/repro/Issue80Repro.t.sol` in a clone of `main`, then moved out of the test tree
so it is **not** part of this PR:

```
$ nix develop -c forge test --match-path 'test/repro/*' -vv
Ran 3 tests for test/repro/Issue80Repro.t.sol:Issue80Repro
[PASS] testNoPublicBeaconGetter() (gas: 64604)
[PASS] testOZ4BeaconIsNotInRuntimeBytecode() (gas: 136606)
[PASS] testOZ5BeaconIsInRuntimeBytecode() (gas: 80870)
Suite result: ok. 3 passed; 0 failed; 0 skipped
```

- v5 shape (immutable + slot write): the 20 beacon bytes **are** in `address(proxy).code`.
- v4 shape (slot only, `sload` on read): they are **not**.
- Neither exposes an ERC-1967 beacon getter, so the original sentence is correct about the slot alone.

## The change

Comment only. One paragraph added stating both shapes and the library's current behaviour ("This library
extracts a beacon address from neither"). No sentence removed, no rationale essay, no history.

## What this PR deliberately does NOT do

Issue #80's triage names the open question as whether to build a `beaconOf(address)` bytecode extractor.
That would add a verdict this library does not currently reach — today it never concludes anything about a
proxy's beacon, only about a beacon you already hold. The option space (exact-template match vs. pattern
scan, and what each newly accepts and newly rejects) is posted on the issue for a human to rule on:
https://github.com/rainlanguage/rain.extrospection/issues/80#issuecomment-5329207689

## Zero verdict change, proven

`Extrospect` compiled `deployedBytecode` object, hashed before and after the edit:

```
before: 737eb98add8cbe3cc1f01a9b45ae7d8416ce8e3595deae6165b5593498987b71
after:  737eb98add8cbe3cc1f01a9b45ae7d8416ce8e3595deae6165b5593498987b71
```

`ExtrospectConstantsTest` pins deployed bytecode and still passes, which is the same fact from the suite's
own side.

## Suite

Unfiltered, `nix develop -c forge test`, identical before and after the edit:

```
Ran 27 test suites: 311 tests passed, 3 failed, 0 skipped (314 total tests)
```

The 3 failures are `LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest`'s fork tests, all
`vm.createSelectFork: environment variable ARBITRUM_RPC_URL not found` — no RPC in this environment. That is
issue #85's subject, and it is red on `main` here too, unchanged by this PR.

## Adversarial mutation pass

The diff is comment-only, so mutating it is vacuous — instead the pass targets the **unit the PR documents**,
`src/lib/LibExtrospectERC1967BeaconProxy.sol`, to state what its tests actually pin.

Harness: `.scratch/mutate.sh`, one `forge test` per mutant from a pristine copy, filter
`--no-match-contract ExtrospectConstantsTest --no-match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'`.

- `ExtrospectConstantsTest` **excluded**: it pins deployed bytecode, so it fails under every source mutation
  and would report KILLED for all of them, measuring nothing.
- The `checkCBORTrimmedBytecodeHash` file **excluded**: needs `ARBITRUM_RPC_URL`, absent here. This drops 7
  tests (4 that pass locally plus the 3 fork failures), so the pass does not exercise
  `checkCBORTrimmedBytecodeHash` at all — none of the mutants below are in that call graph, so nothing was
  lost for this unit.

Filtered baseline, all green, proving the filter matches a real suite rather than nothing:

```
BASELINE|Ran 25 test suites in 875.07ms: 304 tests passed, 0 failed, 0 skipped (304 total tests)
```

| # | Mutant (in `LibExtrospectERC1967BeaconProxy.sol`) | Suite result | Verdict | Killed by (sample) |
|---|---|---|---|---|
| M01 | `isBeaconImplementationBytecode`: drop `ok &&` | 297 passed / **7 failed** | KILLED | `testReturnsFalseOnNoCodeTarget`, `testReturnsFalseOnNonBeaconWithEmptyHash`, `testReturnsFalseOnRevertWithAddressSizedData` |
| M02 | `isBeaconImplementationBytecode`: `return ok;` (drop hash compare) | 302 passed / **2 failed** | KILLED | `testMismatches(bytes32)`, `testImplementationZeroAddressHashesToEmpty(bytes32)` |
| M03 | `isBeaconOwner`: drop `ok &&` | 300 passed / **4 failed** | KILLED | `testReturnsFalseOnNonOwnableWithZeroAddress` |
| M04 | `isBeaconOwner`: `return ok;` (drop owner compare) | 303 passed / **1 failed** | KILLED | `testMismatches(address,address,address)` |
| M05 | `_tryGetAddress`: drop the `returnData.length != 32` guard | 301 passed / **3 failed** | KILLED | `testReturnsFalseOnWrongLengthReturn`, `testReturnsFalseOnNoCodeTarget` |
| M06 | `_tryGetAddress`: drop the `!success` guard | 302 passed / **2 failed** | KILLED | `testReturnsFalseOnRevertWithAddressSizedData` |
| M07 | `_tryGetAddress`: `length != 32` → `length < 32` (accept over-long returns) | 302 passed / **2 failed** | KILLED | `testReturnsFalseOnWrongLengthReturn` |
| M08 | `_tryGetAddress`: delete the dirty-address guard entirely | 302 passed / **2 failed** | KILLED | `testReturnsFalseOnInvalidReturnEncoding(address)`, `testReturnsFalseOnInvalidReturnEncoding(bytes32)` |
| M09 | `_tryGetAddress`: `raw > uint160.max` → `raw >= uint160.max` (off-by-one at the boundary) | 301 passed / **3 failed** | KILLED | `testMatchesAtMaxAddressBoundary` |
| M10 | `_tryGetAddress`: `mload(add(returnData, 0x20))` → `mload(returnData)` (read the length word) | 299 passed / **5 failed** | KILLED | `testMatches`, `testMatchesAtMaxAddressBoundary` |
| M11 | `ERC1967_BEACON_SLOT`: `- 1` → `- 2` | 303 passed / **1 failed** | KILLED | `testBeaconSlotMatchesDerivation` |
| M12 | `ERC1967_IMPLEMENTATION_SLOT`: `- 1` → `- 2` | 303 passed / **1 failed** | KILLED | `testImplementationSlotMatchesDerivation` |
| M13 | `ERC1967_ADMIN_SLOT`: `- 1` → `- 2` | 303 passed / **1 failed** | KILLED | `testAdminSlotMatchesDerivation` |
| M14 | `isBeaconImplementationBytecode` calls `owner()` instead of `implementation()` | 301 passed / **3 failed** | KILLED | `testMatches`, `testMatchesAtMaxAddressBoundary` |
| M15 | `isBeaconOwner` calls `implementation()` instead of `owner()` | 301 passed / **3 failed** | KILLED | `testMatchesAtMaxAddressBoundary` |
| M16 | `_tryGetAddress`: `return (true, address(uint160(raw)))` → `return (true, address(0))` | 299 passed / **5 failed** | KILLED | `testMatches`, `testMatchesAtMaxAddressBoundary` |

Restored-source control run: `304 passed / 0 failed` — same as baseline, so the harness is not leaving
residue between mutants.

Every row above shows a real `Ran 25 test suites … (304 total tests)` line, so the tests ran; a mutant is
KILLED only where `failed > 0` against a `failed = 0` baseline.

**16 mutants, 16 killed, 0 survived.** No compile failures, no zero-match filters, no unpatched mutants —
the harness reports `PATTERN_NOT_FOUND` / `COMPILE_FAIL` / `NO_RUN` distinctly from KILLED and emitted none
of them. Nothing in this unit needs a new discriminating test, so no test is added: the PR stays comment-only.

## QA
- Discriminating tests: n/a for the diff — it is comment-only and adds zero executable tokens, proven by the
  `Extrospect` `deployedBytecode` hash being byte-identical before and after (`737eb98a…`) and by
  `ExtrospectConstantsTest` (which pins deployed bytecode) still passing. No test can distinguish this
  branch from `main` at runtime, so writing one would be a test that asserts prose. The claim behind the diff
  was instead verified by an executable repro run outside the PR (`test/repro/Issue80Repro.t.sol`, 3 passed:
  `testOZ5BeaconIsInRuntimeBytecode`, `testOZ4BeaconIsNotInRuntimeBytecode`, `testNoPublicBeaconGetter`) —
  `testOZ5BeaconIsInRuntimeBytecode` is exactly the assertion the old NatSpec implied was impossible.
- Mutations applied: 16 mutants over the documented unit `src/lib/LibExtrospectERC1967BeaconProxy.sol`,
  16 killed, 0 survived — full table above with the killing test for each. Highlights:
  `return ok && keccak256(impl.code) == expectedRuntimeHash;` -> drop `ok &&` -> `testReturnsFalseOnNoCodeTarget`;
  `if (!success || returnData.length != 32)` -> drop the length arm -> `testReturnsFalseOnWrongLengthReturn`;
  `if (raw > type(uint160).max)` -> `>=` -> `testMatchesAtMaxAddressBoundary`;
  `raw := mload(add(returnData, 0x20))` -> `mload(returnData)` -> `testMatches`;
  `keccak256("eip1967.proxy.beacon")) - 1` -> `- 2` -> `testBeaconSlotMatchesDerivation`.
- Oracle: the OpenZeppelin v5 `BeaconProxy` source itself (`OpenZeppelin/openzeppelin-contracts@v5.4.0`,
  quoted above), independent of anything in this repo, plus the EVM's own observable behaviour — the repro
  reads `address(proxy).code` off a live deployment and searches for the 20 beacon bytes rather than
  trusting any claim about where solc puts immutables. The v4-shaped counter-fixture is the negative control:
  same beacon, no immutable, address absent from the runtime code, which is what makes the corrected NatSpec
  version-qualified rather than flatly reversed.
- Category check: issue #80 asks two things — (A) the NatSpec sentence over-reaches beyond the storage slot,
  and (B) whether the repo should therefore build a `beaconOf(address)` bytecode extractor. (A) is covered by
  this diff. (B) is deliberately NOT covered here: it would add a verdict the library does not currently
  reach, so the option space is posted on the issue for a human ruling
  (https://github.com/rainlanguage/rain.extrospection/issues/80#issuecomment-5329207689) and this PR closes
  #80 only insofar as the filed defect — the false NatSpec — is fixed. If the ruling on (B) is "build it",
  that is a follow-up issue, not a reopen of this one.
