### PR TITLE
Document and pin the EIP-7702 delegated-account behaviour of the beacon predicates

### DIFF
--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -39,6 +39,21 @@ bytes32 constant ERC1967_BEACON_SLOT = bytes32(uint256(keccak256("eip1967.proxy.
 ///   `eth_getStorageAt`, or `sload` from a delegatecall context running
 ///   as the proxy.
 ///
+/// EIP-7702 delegated accounts:
+///
+/// - An account whose code is a 23-byte delegation designator
+///   (`0xef0100` followed by a 20-byte delegate address) runs the
+///   delegate's code on every call, so it answers `implementation()`
+///   and `owner()` and both predicates below can return true for it.
+///   Neither predicate inspects the target's code, so a delegated
+///   account is indistinguishable from a beacon contract in what they
+///   return.
+/// - The account holder repoints or revokes the designator in a single
+///   transaction, so a true from either predicate about such an account
+///   changes without any contract's code changing.
+/// - `keccak256(addr.code)` on a delegated account hashes the 23-byte
+///   designator, not the delegate's runtime bytecode.
+///
 /// The slot constants are exported so callers that have storage access
 /// elsewhere use a single canonical source for the slot addresses.
 library LibExtrospectERC1967BeaconProxy {
@@ -49,7 +64,11 @@ library LibExtrospectERC1967BeaconProxy {
     /// `implementation()` (or whose call reverts) is not a valid beacon
     /// and trivially fails the check — returns false rather than
     /// reverting, so integrators can collapse the predicate into a
-    /// single boolean assertion.
+    /// single boolean assertion. An EIP-7702 delegated account answers
+    /// `implementation()` from its delegate and so satisfies this
+    /// check; when `implementation()` itself returns a delegated
+    /// account, the hash compared is that of its 23-byte delegation
+    /// designator rather than of the delegate's runtime bytecode.
     /// @param beacon The beacon address to query.
     /// @param expectedRuntimeHash The expected `keccak256` of the
     /// implementation's runtime bytecode.
@@ -65,7 +84,9 @@ library LibExtrospectERC1967BeaconProxy {
     /// `expectedOwner`. A target that doesn't expose `owner()` (or
     /// whose call reverts) is not a valid beacon and trivially fails
     /// the check — returns false rather than reverting, so integrators
-    /// can collapse the predicate into a single boolean assertion.
+    /// can collapse the predicate into a single boolean assertion. An
+    /// EIP-7702 delegated account answers `owner()` from its delegate
+    /// and so satisfies this check.
     /// @param beacon The beacon address to query.
     /// @param expectedOwner The owner address the beacon should report.
     /// @return True if the ownership matches. False if the call to

--- a/test/lib/LibEIP7702Designator.sol
+++ b/test/lib/LibEIP7702Designator.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+/// @dev The three-byte prefix of an EIP-7702 delegation designator.
+bytes3 constant EIP7702_DELEGATION_PREFIX = 0xef0100;
+
+/// @dev Total byte length of an EIP-7702 delegation designator: the
+/// three-byte prefix plus a 20-byte delegate address.
+uint256 constant EIP7702_DESIGNATOR_LENGTH = 23;
+
+/// @title LibEIP7702Designator
+/// @notice Test-only builder for the EIP-7702 delegation designator an
+/// authorised account carries as its code, so the shape lives in one
+/// place across the test suite.
+library LibEIP7702Designator {
+    /// @notice Build the delegation designator that points at
+    /// `delegate`.
+    /// @param delegate The address whose code the delegating account
+    /// executes.
+    /// @return The 23-byte designator.
+    function designator(address delegate) internal pure returns (bytes memory) {
+        return bytes.concat(EIP7702_DELEGATION_PREFIX, bytes20(delegate));
+    }
+}

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
@@ -13,6 +13,11 @@ import {
     RevertingWithAddressBeacon,
     REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
 } from "test/concrete/RevertingWithAddressBeacon.sol";
+import {
+    LibEIP7702Designator,
+    EIP7702_DELEGATION_PREFIX,
+    EIP7702_DESIGNATOR_LENGTH
+} from "test/lib/LibEIP7702Designator.sol";
 
 /// @title LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest
 /// @notice Tests `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`.
@@ -125,5 +130,68 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
         RevertingWithAddressBeacon beacon = new RevertingWithAddressBeacon();
         assertEq(keccak256(REVERTING_WITH_ADDRESS_BEACON_PAYLOAD.code), keccak256(""));
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+    }
+
+    /// An account whose code is an EIP-7702 delegation designator runs
+    /// the delegate's code, so `implementation()` is answered by the
+    /// delegate and the predicate returns true for the delegating
+    /// account. The predicate never reads the target's own code, so the
+    /// designator is not distinguished from beacon-contract code.
+    function testMatchesForDelegatedAccountBeacon() external {
+        EmptyContract impl = new EmptyContract();
+        MockBeacon delegate = new MockBeacon(address(impl), address(this));
+        address delegating = address(uint160(uint256(keccak256("delegating beacon"))));
+        vm.etch(delegating, LibEIP7702Designator.designator(address(delegate)));
+
+        assertEq(delegating.code.length, EIP7702_DESIGNATOR_LENGTH);
+        assertEq(bytes3(delegating.code), EIP7702_DELEGATION_PREFIX);
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(delegating, keccak256(address(impl).code))
+        );
+    }
+
+    /// Repointing an EIP-7702 delegation designator at a delegate that
+    /// reports a different implementation flips the predicate for the
+    /// same address, with no change to the code of either delegate.
+    function testDelegatedAccountBeaconRepointChangesResult() external {
+        EmptyContract impl = new EmptyContract();
+        MockBeacon delegate = new MockBeacon(address(impl), address(this));
+        MockBeacon otherDelegate = new MockBeacon(address(delegate), address(this));
+        address delegating = address(uint160(uint256(keccak256("delegating beacon"))));
+
+        vm.etch(delegating, LibEIP7702Designator.designator(address(delegate)));
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(delegating, keccak256(address(impl).code))
+        );
+
+        vm.etch(delegating, LibEIP7702Designator.designator(address(otherDelegate)));
+        assertFalse(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(delegating, keccak256(address(impl).code))
+        );
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                delegating, keccak256(address(delegate).code)
+            )
+        );
+    }
+
+    /// When `implementation()` returns an account whose code is an
+    /// EIP-7702 delegation designator, the hash compared is that of the
+    /// 23-byte designator, not that of the delegate's runtime bytecode.
+    function testDelegatedAccountImplementationHashesDesignator() external {
+        MockBeacon delegate = new MockBeacon(address(this), address(this));
+        address delegating = address(uint160(uint256(keccak256("delegating implementation"))));
+        bytes memory designator = LibEIP7702Designator.designator(address(delegate));
+        vm.etch(delegating, designator);
+        MockBeacon beacon = new MockBeacon(delegating, address(this));
+
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256(designator))
+        );
+        assertFalse(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                address(beacon), keccak256(address(delegate).code)
+            )
+        );
     }
 }

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
@@ -13,6 +13,11 @@ import {
     RevertingWithAddressBeacon,
     REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
 } from "test/concrete/RevertingWithAddressBeacon.sol";
+import {
+    LibEIP7702Designator,
+    EIP7702_DELEGATION_PREFIX,
+    EIP7702_DESIGNATOR_LENGTH
+} from "test/lib/LibEIP7702Designator.sol";
 
 /// @title LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest
 /// @notice Tests `LibExtrospectERC1967BeaconProxy.isBeaconOwner`.
@@ -99,5 +104,37 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest is Test {
         assertFalse(
             LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), REVERTING_WITH_ADDRESS_BEACON_PAYLOAD)
         );
+    }
+
+    /// An account whose code is an EIP-7702 delegation designator runs
+    /// the delegate's code, so `owner()` is answered by the delegate
+    /// and the predicate returns true for the delegating account. The
+    /// predicate never reads the target's own code, so the designator
+    /// is not distinguished from beacon-contract code.
+    function testMatchesForDelegatedAccount(address own) external {
+        MockBeacon delegate = new MockBeacon(address(this), own);
+        address delegating = address(uint160(uint256(keccak256("delegating account"))));
+        vm.etch(delegating, LibEIP7702Designator.designator(address(delegate)));
+
+        assertEq(delegating.code.length, EIP7702_DESIGNATOR_LENGTH);
+        assertEq(bytes3(delegating.code), EIP7702_DELEGATION_PREFIX);
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(delegating, own));
+    }
+
+    /// Repointing an EIP-7702 delegation designator at a delegate that
+    /// reports a different owner flips the predicate for the same
+    /// address, with no change to the code of either delegate.
+    function testDelegatedAccountRepointChangesResult(address own, address otherOwn) external {
+        vm.assume(own != otherOwn);
+        MockBeacon delegate = new MockBeacon(address(this), own);
+        MockBeacon otherDelegate = new MockBeacon(address(this), otherOwn);
+        address delegating = address(uint160(uint256(keccak256("delegating account"))));
+
+        vm.etch(delegating, LibEIP7702Designator.designator(address(delegate)));
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(delegating, own));
+
+        vm.etch(delegating, LibEIP7702Designator.designator(address(otherDelegate)));
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconOwner(delegating, own));
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(delegating, otherOwn));
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/79

## What this is

Issue #79 is half a documentation gap and half a verdict decision. **This PR is only the documentation half.** The verdict half — whether the library should start rejecting EIP-7702 delegated accounts — is posted as an option space on the issue and is not implemented here. Every verdict this library reaches is byte-for-byte unchanged by this diff.

## Reproduced first

The finding was verified on current `main` (`32f7325`) before anything was written, in a fresh clone:

```
Ran 2 tests for test/triage/Repro79.t.sol:Repro79Test
[PASS] testDesignatorStaticcallShape()
Logs:
  ok: 1
  len: 32
  data: 0x000000000000000000000000000000000000000000000000000000000000cafe
  code: 0xef01005615deb798bb3e4dfa0139dfa1b3d433cc23b72f
[PASS] testP11_7702Beacon()
```

A `staticcall` to an account whose code is a 23-byte `0xef0100 || delegate` designator is answered by the delegate, so both predicates return `true` for it and the account holder flips that answer by repointing the designator.

Two things learned doing it, both now on the issue:

- `foundry.toml` pins `evm_version = "cancun"`, yet foundry resolves the designator anyway. The repro exercises Prague semantics under a Cancun-labelled config — which is the semantics that matter, since the deployment targets are post-Pectra.
- On a genuinely pre-Pectra EVM the same 23 bytes are an invalid opcode, the `staticcall` reverts, and both predicates return `false`. This behaviour is new as of Pectra for addresses that already existed.

## Changes

**`src/lib/LibExtrospectERC1967BeaconProxy.sol`** — NatSpec only, no code.

A third section on the library doc, next to the existing "what's possible" / "what's NOT possible" sections, stating what the predicates currently do with a delegated account: they answer from the delegate, they never read the target's own code, the holder changes the answer in one transaction, and `keccak256(addr.code)` on such an account hashes the designator rather than the delegate's runtime code. One sentence added to each predicate's `@notice` naming the case it covers.

**`test/lib/LibEIP7702Designator.sol`** — new test helper. `EIP7702_DELEGATION_PREFIX`, `EIP7702_DESIGNATOR_LENGTH` and a `designator(address)` builder, so the 23-byte shape lives in one place rather than as a repeated literal across the two test files.

**Five new tests** across the two existing subject-path test files:

| test | pins |
| --- | --- |
| `isBeaconOwner :: testMatchesForDelegatedAccount` | a delegated account satisfies `isBeaconOwner` from its delegate |
| `isBeaconOwner :: testDelegatedAccountRepointChangesResult` | repointing the designator flips the verdict for the same address, no delegate code changing |
| `isBeaconImplementationBytecode :: testMatchesForDelegatedAccountBeacon` | a delegated account satisfies `isBeaconImplementationBytecode` from its delegate |
| `isBeaconImplementationBytecode :: testDelegatedAccountBeaconRepointChangesResult` | repointing flips this predicate too |
| `isBeaconImplementationBytecode :: testDelegatedAccountImplementationHashesDesignator` | when `implementation()` returns a delegated account, the hash matched is the 23-byte designator's, **not** the delegate's runtime bytecode's |

## Test runs

Toolchain: `nix develop -c forge test`, forge 1.7.2-nightly (`43923a4`).

Exclusions, both established for this repo today:

- `ExtrospectConstantsTest` — pins deployed bytecode, so it fails under every source mutation and would report KILLED for every mutant, measuring nothing (#84).
- `LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest` — needs `ARBITRUM_RPC_URL`, absent here. **Excluding the whole contract drops 7 tests, not just the 3 fork ones**; the 4 non-fork `checkCBORTrimmedBytecodeHash` paths in it go unmeasured by the matrix below. That is exactly #85.

| run | result |
| --- | --- |
| full suite, no exclusions, `main` @ `32f7325` | 311 passed / 3 failed (all 3 = missing `ARBITRUM_RPC_URL`) / 314 total |
| both exclusions, `main` @ `32f7325` | **304 passed / 0 failed** |
| both exclusions, this branch | **309 passed / 0 failed** (+5 new) |

## Adversarial mutation pass

Subject: `src/lib/LibExtrospectERC1967BeaconProxy.sol`. Every run below reports `309 total tests` on the suite line, so the tests demonstrably ran — no compile-error or zero-match run is being counted as KILLED.

| # | mutation | result | killed by |
| --- | --- | --- | --- |
| M1 | `return ok && keccak256(impl.code) == …` → drop `ok` | KILLED (7 fail) | `testReturnsFalseOnNoCodeTarget`, `…OnNonBeacon`, `…OnBeaconRevert`, `…OnInvalidReturnEncoding`, `…OnWrongLengthReturn`, `…OnRevertWithAddressSizedData`, `…OnNonBeaconWithEmptyHash` |
| M2 | `return ok && own == expectedOwner` → drop `ok` | KILLED (4 fail) | `testReturnsFalseOnNonOwnable`, `…OnNonOwnableWithZeroAddress`, `…OnBeaconRevert`, `…OnInvalidReturnEncoding` |
| M3 | `if (!success \|\| returnData.length != 32)` → `if (!success)` | KILLED (3 fail) | `testReturnsFalseOnNoCodeTarget`, `testReturnsFalseOnWrongLengthReturn` (both files) |
| M4 | same → `if (returnData.length != 32)` | KILLED (2 fail) | `testReturnsFalseOnRevertWithAddressSizedData` (both files) |
| M5 | `returnData.length != 32` → `< 32` | KILLED (2 fail) | `testReturnsFalseOnWrongLengthReturn` (both files) |
| M6 | delete the dirty-address guard | KILLED (2 fail) | `testReturnsFalseOnInvalidReturnEncoding` (both files) |
| M7 | `raw > type(uint160).max` → `>=` | KILLED (5 fail) | `testMatchesAtMaxAddressBoundary` (both files), `testMatches`, **`testMatchesForDelegatedAccount`**, **`testDelegatedAccountRepointChangesResult`** |
| M8 | `mload(add(returnData, 0x20))` → `0x40` | KILLED (13 fail) | `testMatches` ×2, the three `Extrospect…Equivalence` beacon tests, **all 5 new delegated tests**, others |
| M9 | `implementation()` selector → `owner()` selector | KILLED (6 fail) | `testMatches`, `testImplementationZeroAddressHashesToEmpty`, `testMatchesAtMaxAddressBoundary`, **`testMatchesForDelegatedAccountBeacon`**, **`testDelegatedAccountBeaconRepointChangesResult`**, **`testDelegatedAccountImplementationHashesDesignator`** |
| M10 | `owner()` selector → `implementation()` selector | KILLED (5 fail) | `testMatches`, `testMismatches`, `testMatchesAtMaxAddressBoundary`, **`testMatchesForDelegatedAccount`**, **`testDelegatedAccountRepointChangesResult`** |
| M12 | `keccak256(impl.code)` → `keccak256(beacon.code)` | KILLED (6 fail) | `testMatches`, `testImplementationZeroAddressHashesToEmpty`, `testMatchesAtMaxAddressBoundary`, **all 3 new impl-side delegated tests** |
| **M11** | **insert the ruling-under-question guard** — `if (beacon.code.length == 23 && bytes3(beacon.code) == 0xef0100) return false;` into both predicates | **KILLED only by this PR's new tests** | **`testMatchesForDelegatedAccount`, `testDelegatedAccountRepointChangesResult`, `testMatchesForDelegatedAccountBeacon`, `testDelegatedAccountBeaconRepointChangesResult`** |

12 mutants, 12 killed, 0 survived.

M11 is the one that matters. It is Option A from the issue's decision space — the change that would make the library reject delegated accounts — applied as a mutant:

- against the **pre-change** suite (`--no-match-test 'Delegated'`): `304 passed / 0 failed` — **survives**. Nothing in the repo constrained this verdict before.
- against **this branch**: `305 passed / 4 failed` — **killed**.

So the verdict this PR declines to change is now pinned, and any future change to it has to be a deliberate edit to a failing test rather than a silent behaviour drift. `testDelegatedAccountImplementationHashesDesignator` correctly does *not* fail under M11: there the beacon is a real contract and only the implementation is delegated, which M11's target-side guard does not touch.

## What is NOT in this PR

Rejecting delegated accounts (as a beacon target, as an implementation, or both), and any additive `isDelegatedAccount` predicate. All of those change what the library concludes about real addresses. The option space — what each newly accepts, what each newly rejects, and who that affects — is posted on #79 for a human ruling, along with the fact that `0xef0100` is the same discriminant at issue in #53 and #54 and should get one consistent answer and one shared constant.

## QA
- Discriminating tests: `testMatchesForDelegatedAccount`, `testDelegatedAccountRepointChangesResult`, `testMatchesForDelegatedAccountBeacon`, `testDelegatedAccountBeaconRepointChangesResult`, `testDelegatedAccountImplementationHashesDesignator` — these PASS on base and are meant to, because this PR pins existing behaviour rather than changing it; there is no fix for them to fail against. Discrimination was verified the only way it can be here, by mutant: M11 (the guard that would make the library reject EIP-7702 delegated accounts) SURVIVES the base suite — run with `--no-match-test 'Delegated'`, 304 passed / 0 failed — and is KILLED with them present, 305 passed / 4 failed. `testDelegatedAccountImplementationHashesDesignator` is discriminated by M12 and M9 instead, both of which it kills.
- Mutations applied: 12 applied to `src/lib/LibExtrospectERC1967BeaconProxy.sol`, 12 killed, 0 survived. `return ok && keccak256(impl.code) == expectedRuntimeHash` → drop `ok` → killed by 7 `testReturnsFalseOn*` (M1). `return ok && own == expectedOwner` → drop `ok` → 4 `testReturnsFalseOn*` (M2). `if (!success || returnData.length != 32)` → `if (!success)` → `testReturnsFalseOnNoCodeTarget`, `testReturnsFalseOnWrongLengthReturn` (M3). Same line → `if (returnData.length != 32)` → `testReturnsFalseOnRevertWithAddressSizedData` (M4). `returnData.length != 32` → `< 32` → `testReturnsFalseOnWrongLengthReturn` (M5). Delete `if (raw > type(uint160).max) return (false, address(0));` → `testReturnsFalseOnInvalidReturnEncoding` (M6). `raw > type(uint160).max` → `>=` → `testMatchesAtMaxAddressBoundary`, `testMatches`, `testMatchesForDelegatedAccount`, `testDelegatedAccountRepointChangesResult` (M7). `raw := mload(add(returnData, 0x20))` → `0x40` → 13 tests including all 5 new ones (M8). `_tryGetAddress(beacon, IBeacon.implementation.selector)` → `IOwnable.owner.selector` → `testMatches`, `testImplementationZeroAddressHashesToEmpty`, `testMatchesAtMaxAddressBoundary` and all 3 new impl-side tests (M9). `_tryGetAddress(beacon, IOwnable.owner.selector)` → `IBeacon.implementation.selector` → `testMatches`, `testMismatches`, `testMatchesAtMaxAddressBoundary` and both new owner-side tests (M10). `keccak256(impl.code)` → `keccak256(beacon.code)` → `testMatches`, `testImplementationZeroAddressHashesToEmpty`, `testMatchesAtMaxAddressBoundary` and all 3 new impl-side tests (M12). Insert `if (beacon.code.length == 23 && bytes3(beacon.code) == 0xef0100) return false;` into both predicates → killed ONLY by this PR's new tests (M11). Every mutant run printed `309 total tests` on its suite line, so the tests demonstrably ran; per-mutant table with failure counts is above.
- Oracle: EIP-7702 itself. The designator is `0xef0100 || <20-byte delegate>` and an account carrying it executes the delegate's code on `CALL`/`STATICCALL`/`DELEGATECALL`; `test/lib/LibEIP7702Designator.sol` builds that shape from the EIP's constants. Expected owners and implementations come from the constructor arguments the `MockBeacon` delegate fixture was built with, and expected hashes from `keccak256` of a bytes value the test constructed — never from calling the library under test and asserting it agrees with itself.
- Category check: #79 asks two things. (a) That the delegated-account behaviour of both predicates be on the record, including the secondary note that `keccak256(impl.code)` hashes the 23-byte pointer rather than executing code — covered, by NatSpec on the library and both predicates plus the five tests above, the last of which is exactly the pointer-hashing case. (b) A ruling on whether the library should reject delegated accounts — deliberately NOT covered here, because every form of it changes what the library concludes about real addresses; the option space (Options A–E, what each newly accepts, what each newly rejects, who it affects) is posted as a comment on #79 for a human ruling, together with the fact that the same `0xef0100` discriminant is at issue in #53 and #54 and wants one consistent answer and one shared constant.
