### PR TITLE
Document the codeless-implementation verdict of isBeaconImplementationBytecode and pin the counterfactual CREATE2 target

### DIFF
--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -50,6 +50,15 @@ library LibExtrospectERC1967BeaconProxy {
     /// and trivially fails the check — returns false rather than
     /// reverting, so integrators can collapse the predicate into a
     /// single boolean assertion.
+    ///
+    /// An implementation address with no code — an externally owned
+    /// account, an unoccupied `CREATE2` target, a self-destructed
+    /// account, or `address(0)` — reads as empty bytecode and hashes to
+    /// `keccak256("")`, so `expectedRuntimeHash == keccak256("")` is
+    /// satisfied by every codeless implementation. Whether the
+    /// implementation has any code at all is not checked. Deploying code
+    /// to a codeless implementation turns that same call from true to
+    /// false.
     /// @param beacon The beacon address to query.
     /// @param expectedRuntimeHash The expected `keccak256` of the
     /// implementation's runtime bytecode.

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
@@ -48,6 +48,32 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), wrongHash));
     }
 
+    /// Every codeless implementation reads as empty bytecode, so
+    /// `keccak256("")` is matched at a non-zero address the same way it
+    /// is at `address(0)`. An unoccupied `CREATE2` target is codeless
+    /// while the beacon already points at it, and deploying to that
+    /// target turns the same call from true to false.
+    function testCounterfactualImplementationMatchesEmptyHashUntilOccupied() external {
+        bytes32 salt = bytes32(uint256(0x5eed));
+        address counterfactual =
+            vm.computeCreate2Address(salt, keccak256(type(EmptyContract).creationCode), address(this));
+        assertEq(counterfactual.code.length, 0);
+        assertTrue(counterfactual != address(0));
+
+        MockBeacon beacon = new MockBeacon(counterfactual, address(this));
+        assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+
+        assertEq(address(new EmptyContract{salt: salt}()), counterfactual);
+        assertGt(counterfactual.code.length, 0);
+
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                address(beacon), keccak256(counterfactual.code)
+            )
+        );
+    }
+
     /// A target that doesn't expose `implementation()` is not a valid
     /// beacon and trivially fails the predicate. Returns false rather
     /// than reverting so integrators can collapse the check to a single


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/78

## What the issue found, and what is here

`isBeaconImplementationBytecode(beacon, keccak256(""))` returns `true` for any beacon whose `implementation()` is a codeless address, and that `true` is not stable: occupying a counterfactual `CREATE2` target turns the same call to `false`.

**Reproduced against `main` @ `32f7325`.** Not with `vm.etch` — with a real `CREATE2` deployment, so the state change is one an attacker can actually perform:

```solidity
address counterfactual = vm.computeCreate2Address(salt, keccak256(type(EmptyContract).creationCode), address(this));
MockBeacon beacon = new MockBeacon(counterfactual, address(this));
assertTrue(isBeaconImplementationBytecode(address(beacon), keccak256("")));   // codeless target
new EmptyContract{salt: salt}();                                             // occupy it
assertFalse(isBeaconImplementationBytecode(address(beacon), keccak256("")));  // same call, opposite answer
```

**This PR changes no verdict.** It ships only the two halves of the issue that leave every answer identical:

1. The NatSpec hazard the issue says is missing — that a codeless implementation reads as empty bytecode, that `keccak256("")` therefore matches every codeless implementation, that code presence is not checked, and that deploying flips the answer.
2. A test pinning the counterfactual case, so the behaviour is locked rather than incidental.

**The rest is a verdict decision and is not in this PR.** Adding a `code.length` guard, rejecting `keccak256("")` as an argument, or switching to `impl.codehash` each change what the library concludes about some contract. The full option space — what each newly accepts, what each newly rejects, and who that affects — is posted on the issue: https://github.com/rainlanguage/rain.extrospection/issues/78#issuecomment-5329202399

The new test is deliberately the tripwire for those options: mutants M04 and M06 below *are* two of the candidate fixes, and both fail it. Neither can land silently.

One correction to the issue's `codehash` suggestion, carried into that comment: `impl.codehash` is `0` for a **non-existent** account but `keccak256("")` for an **existing** account with no code. It separates "no account" from "account with no code" — not "codeless" from "has code".

## Baseline

`nix develop -c forge test`, excluding `ExtrospectConstantsTest` and `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol`:

- before (fresh clone at `32f7325`): **304 passed / 0 failed / 0 skipped**
- after (this branch): **305 passed / 0 failed / 0 skipped** — +1, the new pinning test. 3 consecutive runs, clean fuzz cache each time.

Excluding the `checkCBORTrimmedBytecodeHash` file costs 7 tests, of which only 3 are the fork tests needing `ARBITRUM_RPC_URL`; the other 4 run fine and are collateral. That is #85.

## Adversarial mutation pass

`src/lib/LibExtrospectERC1967BeaconProxy.sol`, one mutation at a time, whole suite each time.

**Harness honesty.** Three things had to be handled before any number here means anything:

- `ExtrospectConstantsTest` pins deployed bytecode, so it fails under *every* source mutation and would report `KILLED` for every mutant. Excluded.
- Foundry persists fuzz counterexamples to `cache/fuzz/failures` and replays them on every later run. A mutant that breaks a fuzz test therefore poisons *subsequent* mutants with a replayed failure. Two `checkNoSolidityCBORMetadata` fuzz tests got stuck this way (detail below) and were excluded from the campaign; the control row below is what proves the remaining replays produce no false kills.
- The control itself: mutating **a word in a comment** must survive. If it does not, the harness is measuring nothing.

| # | Mutation | Result | Tests failed |
|---|---|---|---|
| **M00** | **CONTROL** — comment word only, no behaviour change | **SURVIVED** | ran 303, 0 failed |
| M01 | `isBeaconImplementationBytecode`: drop the `ok` guard | KILLED | 7 |
| M02 | drop the hash compare (`return ok;`) | KILLED | 3 |
| M03 | `&&` → `\|\|` | KILLED | 10 |
| M04 | `keccak256(impl.code)` → `impl.codehash` *(candidate fix D)* | KILLED | 3 |
| M05 | hash the beacon instead of the implementation | KILLED | 4 |
| M06 | add the codeless guard *(candidate fix B)* | KILLED | 3 |
| M07 | `_tryGetAddress`: drop the `success` check | KILLED | 2 |
| M08 | `_tryGetAddress`: drop the length check | KILLED | 3 |
| M09 | `_tryGetAddress`: `length != 32` → `length < 32` | KILLED | 2 |
| M10 | `_tryGetAddress`: drop the dirty-address check | KILLED | 2 |
| M11 | `_tryGetAddress`: `raw > max` → `raw >= max` | KILLED | 3 |
| M12 | `_tryGetAddress`: read returndata at `0x00` not `0x20` | KILLED | 6 |
| M13 | `isBeaconOwner`: drop the `ok` guard | KILLED | 4 |

**13 killed, 0 survived, control survived.**

Killers for the two candidate fixes are the same three tests, one of which is new here:

- **M04** (`impl.codehash`) and **M06** (codeless guard) — `testCounterfactualImplementationMatchesEmptyHashUntilOccupied` *(new)*, `testImplementationZeroAddressHashesToEmpty`, `testMatchesAtMaxAddressBoundary`

### Proof the tests ran

Every row asserts the run reached **exactly 303 tests**; a run that compiled but did not execute, or executed a different set, is recorded as `BAD-TOTAL`/`NO-SUMMARY` rather than `KILLED`. No row hit those. A no-op `sed` is recorded as `NO-OP-SED` rather than silently scoring, so a mutation that failed to apply cannot read as `SURVIVED`. The `SURVIVED` control row carries its own count (`ran 303 tests, 0 failed`), so "survived" cannot be silence from a suite that never ran.

Killer *names* are de-duplicated across the two beacon test files, which share several test names — so a name list is sometimes shorter than the failure count (e.g. M07's 2 failures are `testReturnsFalseOnRevertWithAddressSizedData` in both the `isBeaconImplementationBytecode` and `isBeaconOwner` files).

## Found on the way, not fixed here

`testCheckNoMetadataPassesFuzz` and `testCheckNoMetadataRevertsFuzz` in `test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol` fuzz arbitrary `bytes` straight into `vm.etch`. Some of that input space is not etchable: a 23-byte value beginning `0xef01` is an EIP-7702 delegation designator, and `vm.etch` rejects it with `failed to create bytecode: Eip7702 is not 23 bytes long`. The fuzzer reached one during this campaign, and because Foundry persists counterexamples the failure then replayed on every subsequent run until `cache/fuzz/failures` was deleted.

So it is rare per-run but sticky once hit: CI goes red at whatever seed finds it, and a developer who hits it locally stays red until they clear the cache. `vm.assume` on the etchable shape would close it. Unrelated to this issue; flagged separately as #118 rather than folded in here.

## QA

- Discriminating tests: `testCounterfactualImplementationMatchesEmptyHashUntilOccupied`. It **passes on base**, by construction — this PR deliberately moves no verdict, so no fail-on-base test can exist for it. Its discrimination is against the *candidate fixes* rather than against base: it fails under M04 (`impl.codehash`) and M06 (`impl.code.length != 0` guard), verified by applying each mutation and observing the failure. That is the property worth locking, since both candidates are live options on the issue.
- Mutations applied: 13 across `src/lib/LibExtrospectERC1967BeaconProxy.sol`, all killed; comment-only control survived (`ran 303 tests, 0 failed`). Full table above. The two that bear on this issue:
  - `keccak256(impl.code) == expectedRuntimeHash` -> `impl.codehash == expectedRuntimeHash` -> killed by `testCounterfactualImplementationMatchesEmptyHashUntilOccupied`, `testImplementationZeroAddressHashesToEmpty`, `testMatchesAtMaxAddressBoundary`
  - `return ok && keccak256(...)` -> `return ok && impl.code.length != 0 && keccak256(...)` -> killed by the same three
- Oracle: EVM semantics, not the implementation. `keccak256("") = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` is fixed by the spec; the counterfactual address comes from the EIP-1014 formula (salt + init-code hash + deployer) via `vm.computeCreate2Address`, and the test asserts the deployment actually lands there (`assertEq(address(new EmptyContract{salt: salt}()), counterfactual)`) rather than trusting either side. Each expected `true`/`false` is decided by "does this account have code right now", determined independently of the library under test.
- Category check: the issue asks for two things — (a) the missing NatSpec warning about the `keccak256("")` collapse and its instability, (b) a guard (`impl.code.length` or `impl.codehash`). Covered (a). Deliberately NOT covered (b): it changes what the library concludes about a contract, so per the standing rule the option space is posted on the issue for a human decision rather than chosen here — https://github.com/rainlanguage/rain.extrospection/issues/78#issuecomment-5329202399
