### PR TITLE
Document the two expected-hash conventions on IExtrospectV1

### DIFF
--- a/src/concrete/Extrospect.sol
+++ b/src/concrete/Extrospect.sol
@@ -36,8 +36,8 @@ bytes constant EXTROSPECT_CREATION_BYTECODE_V1 =
 /// contract directly.
 contract Extrospect is IExtrospectV1 {
     /// @inheritdoc IExtrospectV1
-    function checkCBORTrimmedBytecodeHash(address account, bytes32 expected) external view {
-        LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(account, expected);
+    function checkCBORTrimmedBytecodeHash(address account, bytes32 expectedTrimmedHash) external view {
+        LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(account, expectedTrimmedHash);
     }
 
     /// @inheritdoc IExtrospectV1

--- a/src/interface/IExtrospectV1.sol
+++ b/src/interface/IExtrospectV1.sol
@@ -8,7 +8,12 @@ pragma solidity ^0.8.25;
 /// test files under `test/src/concrete/Extrospect.<fn>.t.sol`.
 interface IExtrospectV1 {
     /// @notice See `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash`.
-    function checkCBORTrimmedBytecodeHash(address account, bytes32 expected) external view;
+    /// @param account The account whose bytecode to check.
+    /// @param expectedTrimmedHash `keccak256` of `account`'s runtime bytecode
+    /// with the 53-byte Solidity CBOR metadata trailer removed. Not the same
+    /// value as `isBeaconImplementationBytecode`'s `expectedRuntimeHash`,
+    /// which hashes runtime bytecode whole.
+    function checkCBORTrimmedBytecodeHash(address account, bytes32 expectedTrimmedHash) external view;
 
     /// @notice See `LibExtrospectBytecode.checkNoSolidityCBORMetadata`.
     function checkNoSolidityCBORMetadata(address account) external view;
@@ -20,6 +25,11 @@ interface IExtrospectV1 {
     function checkNotMetamorphic(bytes memory bytecode) external pure;
 
     /// @notice See `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`.
+    /// @param beacon The beacon address to query.
+    /// @param expectedRuntimeHash `keccak256` of the implementation's whole
+    /// runtime bytecode, including any Solidity CBOR metadata trailer. Not the
+    /// same value as `checkCBORTrimmedBytecodeHash`'s `expectedTrimmedHash`,
+    /// which hashes runtime bytecode with that trailer removed.
     function isBeaconImplementationBytecode(address beacon, bytes32 expectedRuntimeHash) external view returns (bool);
 
     /// @notice See `LibExtrospectERC1967BeaconProxy.isBeaconOwner`.

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -124,16 +124,19 @@ library LibExtrospectBytecode {
     /// metadata, matches an expected hash. Reverts if the metadata was not
     /// trimmed or if the hash does not match after trimming.
     /// @param account The account whose bytecode to check.
-    /// @param expected The expected hash of the trimmed bytecode.
-    function checkCBORTrimmedBytecodeHash(address account, bytes32 expected) internal view {
+    /// @param expectedTrimmedHash The expected hash of the trimmed bytecode.
+    /// Not the same value as
+    /// `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`'s
+    /// `expectedRuntimeHash`, which hashes runtime bytecode whole.
+    function checkCBORTrimmedBytecodeHash(address account, bytes32 expectedTrimmedHash) internal view {
         bytes memory bytecode = account.code;
         bool didTrim = tryTrimSolidityCBORMetadata(bytecode);
         if (!didTrim) {
             revert MetadataNotTrimmed();
         }
         bytes32 actual = keccak256(bytecode);
-        if (expected != actual) {
-            revert BytecodeHashMismatch(expected, actual);
+        if (expectedTrimmedHash != actual) {
+            revert BytecodeHashMismatch(expectedTrimmedHash, actual);
         }
     }
 

--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -52,7 +52,11 @@ library LibExtrospectERC1967BeaconProxy {
     /// single boolean assertion.
     /// @param beacon The beacon address to query.
     /// @param expectedRuntimeHash The expected `keccak256` of the
-    /// implementation's runtime bytecode.
+    /// implementation's whole runtime bytecode, including any Solidity CBOR
+    /// metadata trailer. Not the same value as
+    /// `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash`'s
+    /// `expectedTrimmedHash`, which hashes runtime bytecode with that trailer
+    /// removed.
     /// @return True if the beacon's current implementation has matching
     /// runtime bytecode. False if the call to `implementation()` fails
     /// for any reason.

--- a/test/concrete/SolidityCBORFixture.sol
+++ b/test/concrete/SolidityCBORFixture.sol
@@ -7,8 +7,13 @@ pragma solidity =0.8.25;
 /// `test/src/lib/LibExtrospectBytecode.*` and in
 /// `test/src/concrete/Extrospect.*` to exercise the trim and reject paths.
 ///
-/// Layout: `6080604052600080fd` (push 0x80, push 0x40, mstore, push 0,
-/// dup1, revert) followed by the 53-byte CBOR trailer
+/// Layout: `6080604052600080fdfe` (push 0x80, push 0x40, mstore, push 0,
+/// dup1, revert, invalid) followed by the 53-byte CBOR trailer
 /// `a26469706673...000819 0033` (ipfs hash + solc 0.8.25 marker + length).
 bytes constant SOLIDITY_CBOR_RUNTIME_FIXTURE =
     hex"6080604052600080fdfea26469706673582212200726074213b9ef2f5b41bf0bdd5bbd03a64652de62f1dfcda59625e106c52e8a64736f6c63430008190033";
+
+/// @dev `SOLIDITY_CBOR_RUNTIME_FIXTURE` with its 53-byte CBOR trailer
+/// removed, i.e. the bytes `tryTrimSolidityCBORMetadata` leaves behind and
+/// the preimage of the hash `checkCBORTrimmedBytecodeHash` matches.
+bytes constant SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED = hex"6080604052600080fdfe";

--- a/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
@@ -5,6 +5,10 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibExtrospectTestProd} from "test/lib/LibExtrospectTestProd.sol";
 import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
+import {
+    SOLIDITY_CBOR_RUNTIME_FIXTURE,
+    SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED
+} from "test/concrete/SolidityCBORFixture.sol";
 
 contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
     address constant PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1 = address(0xe01Db32B1E03976b24e3A948A560f4b97Dd732dA);
@@ -120,5 +124,26 @@ contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.MetadataNotTrimmed.selector));
         this.externalCheckCBORTrimmedBytecodeHash(target, anyHash);
+    }
+
+    /// The hash this check matches is `keccak256` of the account's bytecode
+    /// with the 53-byte Solidity CBOR trailer removed. The whole-runtime hash
+    /// that `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`
+    /// matches for the same account is a different value, and reverts here.
+    function testCheckCBORTrimmedBytecodeHashRejectsWholeRuntimeHash() external {
+        address target = address(0xBEEF);
+        vm.etch(target, SOLIDITY_CBOR_RUNTIME_FIXTURE);
+
+        assertEq(SOLIDITY_CBOR_RUNTIME_FIXTURE.length, SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED.length + 53);
+
+        bytes32 trimmedHash = keccak256(SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED);
+        bytes32 wholeRuntimeHash = keccak256(SOLIDITY_CBOR_RUNTIME_FIXTURE);
+
+        LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(target, trimmedHash);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(LibExtrospectBytecode.BytecodeHashMismatch.selector, wholeRuntimeHash, trimmedHash)
+        );
+        this.externalCheckCBORTrimmedBytecodeHash(target, wholeRuntimeHash);
     }
 }

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
@@ -10,6 +10,10 @@ import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
 import {
+    SOLIDITY_CBOR_RUNTIME_FIXTURE,
+    SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED
+} from "test/concrete/SolidityCBORFixture.sol";
+import {
     RevertingWithAddressBeacon,
     REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
 } from "test/concrete/RevertingWithAddressBeacon.sol";
@@ -125,5 +129,29 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
         RevertingWithAddressBeacon beacon = new RevertingWithAddressBeacon();
         assertEq(keccak256(REVERTING_WITH_ADDRESS_BEACON_PAYLOAD.code), keccak256(""));
         assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+    }
+
+    /// The hash this predicate matches is `keccak256` of the
+    /// implementation's whole runtime bytecode, CBOR metadata trailer
+    /// included. The trimmed hash that
+    /// `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash` matches for the
+    /// same implementation is a different value, and is rejected here.
+    function testRejectsCBORTrimmedHash() external {
+        address impl = address(0xbeef);
+        vm.etch(impl, SOLIDITY_CBOR_RUNTIME_FIXTURE);
+        MockBeacon beacon = new MockBeacon(impl, address(this));
+
+        assertEq(SOLIDITY_CBOR_RUNTIME_FIXTURE.length, SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED.length + 53);
+
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                address(beacon), keccak256(SOLIDITY_CBOR_RUNTIME_FIXTURE)
+            )
+        );
+        assertFalse(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                address(beacon), keccak256(SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED)
+            )
+        );
     }
 }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/81

## What was wrong

`IExtrospectV1` exposes two `bytes32` "expected hash of a contract's code" parameters produced by incompatible procedures, and documented both with a bare `/// @notice See Lib…`:

- `checkCBORTrimmedBytecodeHash(address account, bytes32 expected)` matches the hash of runtime bytecode **with the 53-byte Solidity CBOR trailer removed**.
- `isBeaconImplementationBytecode(address beacon, bytes32 expectedRuntimeHash)` matches the hash of runtime bytecode **whole**.

Neither parameter said which procedure produces it, and neither mentioned the other. One of the two was named nothing more specific than `expected`.

## Verified against main

Reproduced at `32f7325` with the fixture bytecode `SOLIDITY_CBOR_RUNTIME_FIXTURE` (63 bytes = 10 bytes of runtime + the 53-byte trailer) etched behind a `MockBeacon`:

- `isBeaconImplementationBytecode(beacon, keccak256(trimmed))` returns a silent `false`.
- `checkCBORTrimmedBytecodeHash(account, keccak256(whole))` reverts `BytecodeHashMismatch`.

Both are now pinned as tests rather than left as prose.

## What changed

No verdict moves. Every input the library accepted before it accepts now, and every input it rejected it still rejects — the diff is NatSpec, one parameter name, one shared test constant, and two tests.

- `IExtrospectV1`: `@param` on both parameters of each of the two functions, each naming its own hash procedure and stating that it is not the other's value.
- `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash` and `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`: the same cross-reference on the library NatSpec, where internal callers read it.
- `expected` → `expectedTrimmedHash` on the interface, the concrete and the library, so the two parameters are distinguishable by name at the call site and in the ABI. Parameter names are not in the compiled bytecode: `bytecode_hash = "none"` and `cbor_metadata = false`, and `ExtrospectConstantsTest`'s three pins (creation bytecode, runtime codehash, Zoltu address) pass unchanged.
- `SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED` added next to the existing fixture as the shared trimmed preimage; the neighbouring layout comment was one byte short of the constant it describes (`6080604052600080fd` for `6080604052600080fdfe`) and now matches.
- One test each side pinning that each function rejects the other's hash.

The remaining `@param`/`@return` gaps on the other ten interface functions are #89 and are untouched here.

## Tests

`nix develop -c forge test` on the branch: **313 passed / 3 failed / 316 total**. The 3 failures are `testCheckCBORTrimmedBytecodeHash{Success,Failure,MetadataNotTrimmed}`, which are `vm.createSelectFork` tests failing on `ARBITRUM_RPC_URL not found` in this environment. Identical 3 failures on unmodified `32f7325` (314 total there, before the 2 tests this PR adds).

`nix develop -c forge fmt --check` passes.

## Adversarial mutation pass

Exclusions, and what each costs:

- `--no-match-contract ExtrospectConstantsTest` — its three pins are on compiled bytecode, so they fail under **every** source mutation and would report KILLED for everything, measuring nothing (#84).
- `--no-match-test 'testCheckCBORTrimmedBytecodeHash(Success|Failure|MetadataNotTrimmed)'` — the 3 fork tests, absent an RPC URL. Named individually rather than excluding the whole file, so the other 5 tests in it — including the one this PR adds — still run. That is 3 tests lost, not the 7 that a whole-file exclusion costs (#85).

Filtered baseline: **310 passed / 0 failed / 0 skipped (310 total)**. Every mutant run below reports the same 310 total, so the tests ran.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | `checkCBORTrimmedBytecodeHash` hashes before trimming — i.e. adopts the whole-runtime convention | KILLED (4 failed) | `testCheckCBORTrimmedBytecodeHashRejectsWholeRuntimeHash` **(new)**, `…Fuzz`, `…EquivalencePass`, `…EquivalenceRevertHashMismatch` |
| M2 | `if (expectedTrimmedHash != actual)` → `if (false)`: never revert on mismatch | KILLED (3 failed) | `testCheckCBORTrimmedBytecodeHashRejectsWholeRuntimeHash` **(new)**, `…Fuzz`, `…EquivalenceRevertHashMismatch` |
| M3 | `mstore(bytecode, sub(length, 53))` → `sub(length, 52)`: trim one byte short | KILLED (5 failed) | `testCheckCBORTrimmedBytecodeHashRejectsWholeRuntimeHash` **(new)**, `testTryTrimSolidityCBORMetadataExactly53BytesValid`, `…BytecodeReal`, `…BytecodeContrived`, `…Fuzz` |
| M4 | `isBeaconImplementationBytecode` trims CBOR metadata before hashing — i.e. adopts the trimmed convention | KILLED (1 failed) | `testRejectsCBORTrimmedHash` **(new)** — **the only test in the repo that kills it**; all 11 pre-existing tests in that file pass the mutant |
| M5 | `return ok && …` → `return …`: drop the staticcall success guard | KILLED (7 failed) | `testReturnsFalseOnNonBeacon`, `…OnBeaconRevert`, `…OnInvalidReturnEncoding`, `…OnNoCodeTarget`, `…OnNonBeaconWithEmptyHash`, `…OnRevertWithAddressSizedData`, `…OnWrongLengthReturn` |
| M6 | Drop the `MetadataNotTrimmed` guard | KILLED (3 failed) | `testCheckCBORTrimmedBytecodeHashEmptyAccount`, `…NoMetadataFuzz`, `…EquivalenceRevertNotTrimmed` |
| M7 | `SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED` shortened by one byte (fixture mutant) | KILLED (2 failed) | `testCheckCBORTrimmedBytecodeHashRejectsWholeRuntimeHash` **(new)**, `testRejectsCBORTrimmedHash` **(new)** |

7 mutants, 7 killed, 0 survived.

M4 is the one that justifies the tests rather than docs alone: swapping the beacon predicate onto the CBOR-trimmed convention — the exact confusion this issue is about, as a source bug — passed the entire suite before this PR. M7 confirms neither new test is vacuous: both fail if the shared trimmed constant stops being the real trimmed preimage.

## QA
- Discriminating tests: `testRejectsCBORTrimmedHash` — kills M4, which all 11 pre-existing tests in that file pass (verified by applying M4 and observing it as the sole failure out of 310). `testCheckCBORTrimmedBytecodeHashRejectsWholeRuntimeHash` — kills M1, M2, M3, M7. Both fail under M7, the fixture-constant mutant, so neither is vacuous.
- Mutations applied: `LibExtrospectBytecode.sol:133` hash moved before the trim call (M1) -> `testCheckCBORTrimmedBytecodeHashRejectsWholeRuntimeHash`; `:138` `expectedTrimmedHash != actual` -> `false` (M2) -> same test; `:118` `sub(length, 53)` -> `sub(length, 52)` (M3) -> same test plus 3 trim tests; `LibExtrospectERC1967BeaconProxy.sol:61` `keccak256(impl.code)` -> `keccak256(trimmed(impl.code))` (M4) -> `testRejectsCBORTrimmedHash` only; `:61` drop `ok &&` (M5) -> 7 beacon tests; `LibExtrospectBytecode.sol:134-137` drop the `MetadataNotTrimmed` guard (M6) -> 3 tests; `SolidityCBORFixture.sol` trimmed constant shortened one byte (M7) -> both new tests. 7 applied, 7 killed, 0 survived; every run reports 310 total tests, so the suite ran.
- Oracle: the fixture's documented byte layout, not the implementation. `SOLIDITY_CBOR_RUNTIME_FIXTURE_TRIMMED` is the literal 10-byte prefix `6080604052600080fdfe` written out, not the result of calling `tryTrimSolidityCBORMetadata`, and each test asserts `whole.length == trimmed.length + 53` against the 53 bytes the Solidity metadata encoding fixes.
- Category check: issue asks that each parameter say which hash procedure produces it, and that each cross-reference the other. Both covered, on the interface and on both libraries, plus the parameter rename the issue names as the other half of the cheapest fix. Its closing note that this is "part of the broader IExtrospectV1 has no @param/@return documentation issue" is #89 and is deliberately out of scope here.
