### PR TITLE
feat: expose the beacon implementation address from LibExtrospectERC1967BeaconProxy

### DIFF
--- a/src/lib/LibExtrospectERC1967BeaconProxy.sol
+++ b/src/lib/LibExtrospectERC1967BeaconProxy.sol
@@ -42,6 +42,22 @@ bytes32 constant ERC1967_BEACON_SLOT = bytes32(uint256(keccak256("eip1967.proxy.
 /// The slot constants are exported so callers that have storage access
 /// elsewhere use a single canonical source for the slot addresses.
 library LibExtrospectERC1967BeaconProxy {
+    /// @notice Read a beacon's current implementation address via
+    /// `IBeacon.implementation()`. Yields `(false, address(0))` rather
+    /// than reverting for a target that doesn't expose
+    /// `implementation()`, whose call reverts, or whose return data is
+    /// not exactly 32 bytes holding a clean address. Callers that need
+    /// the implementation's bytecode properties feed the returned
+    /// address to `LibExtrospectMetamorphic` / `LibExtrospectBytecode`.
+    /// @param beacon The beacon address to query.
+    /// @return True if the call to `implementation()` returned a clean
+    /// address. False if it failed for any reason.
+    /// @return The implementation address the beacon reports.
+    /// `address(0)` whenever the first return value is false.
+    function beaconImplementation(address beacon) internal view returns (bool, address) {
+        return _tryGetAddress(beacon, IBeacon.implementation.selector);
+    }
+
     /// @notice Verify that a beacon's current implementation has runtime
     /// bytecode matching `expectedRuntimeHash`. Useful for asserting a
     /// known-good implementation is behind the beacon without trusting

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.beaconImplementation.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.beaconImplementation.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibExtrospectERC1967BeaconProxy} from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
+import {LibExtrospectMetamorphic} from "src/lib/LibExtrospectMetamorphic.sol";
+import {MockBeacon} from "test/concrete/MockBeacon.sol";
+import {EmptyContract} from "test/concrete/EmptyContract.sol";
+import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
+import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
+import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
+import {HasSelfdestruct} from "test/concrete/HasSelfdestruct.sol";
+import {NonMetamorphic} from "test/concrete/NonMetamorphic.sol";
+import {
+    RevertingWithAddressBeacon,
+    REVERTING_WITH_ADDRESS_BEACON_PAYLOAD
+} from "test/concrete/RevertingWithAddressBeacon.sol";
+
+/// @title LibExtrospectERC1967BeaconProxyBeaconImplementationTest
+/// @notice Tests `LibExtrospectERC1967BeaconProxy.beaconImplementation`.
+contract LibExtrospectERC1967BeaconProxyBeaconImplementationTest is Test {
+    /// Returns the address the beacon reports from `implementation()`.
+    function testReturnsImplementation() external {
+        EmptyContract impl = new EmptyContract();
+        MockBeacon beacon = new MockBeacon(address(impl), address(this));
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertTrue(ok);
+        assertEq(actual, address(impl));
+    }
+
+    /// The implementation address is read from `implementation()`, not
+    /// from `owner()`: a beacon whose two getters disagree yields the
+    /// implementation.
+    function testReadsImplementationNotOwner() external {
+        EmptyContract impl = new EmptyContract();
+        address own = address(uint160(0xBEEF));
+        MockBeacon beacon = new MockBeacon(address(impl), own);
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertTrue(ok);
+        assertEq(actual, address(impl));
+        assertTrue(actual != own);
+    }
+
+    /// A beacon reporting `address(0)` is a successful read of the zero
+    /// address, not a failure.
+    function testReturnsZeroImplementation() external {
+        MockBeacon beacon = new MockBeacon(address(0), address(this));
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertTrue(ok);
+        assertEq(actual, address(0));
+    }
+
+    /// `address(type(uint160).max)` is the largest valid 160-bit
+    /// address, accepted by the strict upper-bits check.
+    function testReturnsMaxAddressImplementation() external {
+        address maxAddr = address(type(uint160).max);
+        MockBeacon beacon = new MockBeacon(maxAddr, address(this));
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertTrue(ok);
+        assertEq(actual, maxAddr);
+    }
+
+    /// A target that doesn't expose `implementation()` yields
+    /// `(false, address(0))`.
+    function testFalseOnNonBeacon() external {
+        EmptyContract notABeacon = new EmptyContract();
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(notABeacon));
+        assertFalse(ok);
+        assertEq(actual, address(0));
+    }
+
+    /// A beacon whose `implementation()` reverts yields
+    /// `(false, address(0))`.
+    function testFalseOnRevert() external {
+        RevertingBeacon beacon = new RevertingBeacon();
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertFalse(ok);
+        assertEq(actual, address(0));
+    }
+
+    /// A beacon whose `implementation()` returns 32 bytes with non-zero
+    /// upper 12 bytes yields `(false, address(0))` rather than the
+    /// truncated low 160 bits.
+    function testFalseOnDirtyAddress() external {
+        BogusBeacon beacon = new BogusBeacon();
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertFalse(ok);
+        assertEq(actual, address(0));
+        assertTrue(actual != address(type(uint160).max));
+    }
+
+    /// A beacon whose `implementation()` returns more than 32 bytes
+    /// yields `(false, address(0))`, even though the first word
+    /// (`0x20`, the offset of an empty `string memory`) decodes as a
+    /// clean address.
+    function testFalseOnWrongLengthReturn() external {
+        WrongLengthBeacon beacon = new WrongLengthBeacon();
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertFalse(ok);
+        assertEq(actual, address(0));
+        assertTrue(actual != address(uint160(0x20)));
+    }
+
+    /// `staticcall` to a no-code target returns success with empty
+    /// returndata, which the length check rejects.
+    function testFalseOnNoCodeTarget() external view {
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(0));
+        assertFalse(ok);
+        assertEq(actual, address(0));
+    }
+
+    /// A beacon whose `implementation()` reverts with exactly 32 bytes
+    /// that decode cleanly as an address yields `(false, address(0))`:
+    /// only the staticcall's success flag separates this from a
+    /// successful return of the same bytes.
+    function testFalseOnRevertWithAddressSizedData() external {
+        RevertingWithAddressBeacon beacon = new RevertingWithAddressBeacon();
+        (bool ok, address actual) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(beacon));
+        assertFalse(ok);
+        assertEq(actual, address(0));
+        assertTrue(actual != REVERTING_WITH_ADDRESS_BEACON_PAYLOAD);
+    }
+
+    /// The returned address composes with the repo's own bytecode
+    /// checks: a beacon serving a `SELFDESTRUCT`-carrying
+    /// implementation is rejected by `checkNotMetamorphic`, and one
+    /// serving a clean implementation passes.
+    function testComposesWithMetamorphicCheck() external {
+        HasSelfdestruct risky = new HasSelfdestruct();
+        MockBeacon riskyBeacon = new MockBeacon(address(risky), address(this));
+        (bool riskyOk, address riskyImpl) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(riskyBeacon));
+        assertTrue(riskyOk);
+        uint256 risk = LibExtrospectMetamorphic.scanMetamorphicRisk(riskyImpl.code);
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectMetamorphic.Metamorphic.selector, risk));
+        this.externalCheckNotMetamorphic(riskyImpl.code);
+
+        NonMetamorphic clean = new NonMetamorphic();
+        MockBeacon cleanBeacon = new MockBeacon(address(clean), address(this));
+        (bool cleanOk, address cleanImpl) = LibExtrospectERC1967BeaconProxy.beaconImplementation(address(cleanBeacon));
+        assertTrue(cleanOk);
+        this.externalCheckNotMetamorphic(cleanImpl.code);
+    }
+
+    /// @dev External hop so `vm.expectRevert` has a call boundary to
+    /// attach to.
+    function externalCheckNotMetamorphic(bytes memory bytecode) external pure {
+        LibExtrospectMetamorphic.checkNotMetamorphic(bytecode);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/82

## The claim, checked against `main` @ `32f7325`

Reproduced:

- `LibExtrospectERC1967BeaconProxy._tryGetAddress` is `private view`; `isBeaconImplementationBytecode` and `isBeaconOwner` both return a bare `bool`.
- `IExtrospectV1` has no entry point yielding a beacon's implementation address, so nothing in the repo can hand that address to `checkNotMetamorphic` / `checkNotEOFBytecode` — the caller has to re-implement the staticcall, including the return-length and dirty-address handling the NatSpec argues is the reason for the low-level call.

Not reproduced — the issue's "related asymmetry": *"every other check in `IExtrospectV1` ships a reverting `check*` twin with a typed error"*. Four of the twelve entry points have no reverting twin: `isERC1167Proxy`, `scanEVMOpcodesPresentInBytecode`, `scanEVMOpcodesReachableInBytecode`, `tryTrimSolidityCBORMetadata`. The boolean-only beacon predicates are not exceptional, so no `check*` twins are added here.

## What this changes

`LibExtrospectERC1967BeaconProxy.beaconImplementation(address) internal view returns (bool, address)` — the beacon's `implementation()` read, with the same four failure modes folded into the boolean that `_tryGetAddress` already folded them into.

**No verdict changes.** `isBeaconImplementationBytecode` and `isBeaconOwner` answer identically for every input; their bodies are untouched.

## What this deliberately does not change, and why

`Extrospect` V1 is live on chain at `EXTROSPECT_ZOLTU_ADDRESS_V1` = `0x1BE878af679C1a0A6AC15108b0F4398de1f94506` — Arbitrum One, Base and Polygon PoS all carry byte-identical 3015-byte runtime whose codehash is exactly `EXTROSPECT_RUNTIME_CODEHASH_V1` (`0x6f34c52c…71cf`). Ethereum mainnet, OP Mainnet and BNB Chain have no code there.

So two things the issue asks for are the same decision — redeploy V1 or not — and both are left to the human:

1. **Exposing the accessor on `IExtrospectV1` / `Extrospect`.** A 13th function changes the creation code, so the Zoltu address moves and all three `EXTROSPECT_*_V1` pins have to be re-cut.
2. **Giving the two predicates the shared seam the issue asks for.** Routing `isBeaconImplementationBytecode` through the new accessor is semantically a no-op, but the compiler emits a separate jump target: runtime 3015 → 3022 bytes, and both the creation-code and runtime-code pins drift. Measured, not assumed — that build fails `ExtrospectConstantsTest` on `testExtrospectCreationBytecode` and `testExtrospectRuntimeCodehash`.

Hence the predicate body is left byte-for-byte as it was, at the cost of `_tryGetAddress(beacon, IBeacon.implementation.selector)` appearing in two places. Evidence the live deploy is untouched: the full `ExtrospectConstantsTest` passes on this branch (3/3), including `testExtrospectCreationBytecode`.

The option space (A: library-only / B: extend V1 + redeploy / C: `IExtrospectV2` alongside / D: stop at A) is posted on issue #82.

## Tests

`test/src/lib/LibExtrospectERC1967BeaconProxy.beaconImplementation.t.sol`, 11 tests: the reported address for a normal, zero-address and `type(uint160).max` beacon; that the read comes from `implementation()` and not `owner()`; and `(false, address(0))` for each failure mode — no selector, reverting selector, dirty upper bits, over-long return, no-code target, and a revert whose payload is byte-identical to a successful address return. Plus `testComposesWithMetamorphicCheck`, the regression test for the issue itself: the returned address is fed to `LibExtrospectMetamorphic.checkNotMetamorphic`, which reverts for a `SELFDESTRUCT`-bearing implementation and passes for a clean one.

### Runs

Both runs are `nix develop -c forge test`, excluding `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` (needs `ARBITRUM_RPC_URL`, absent in this environment — 7 tests not run; that gap is issue #85).

| | result |
| --- | --- |
| `main` @ `32f7325` | 307 passed, 0 failed |
| this branch | **318 passed, 0 failed** (+11 new) |

`ExtrospectConstantsTest` is included in both and passes in both.

## Adversarial mutation pass

Each mutant applied to `src/lib/LibExtrospectERC1967BeaconProxy.sol` on the committed branch head, then the whole suite run. `ExtrospectConstantsTest` is excluded **here only** — it pins compiled bytecode, so it fails under every source mutation and would report KILLED for everything while measuring nothing. Baseline with both exclusions: 315 passed / 0 failed, which is the proof each run below actually compiled and ran.

| # | Mutation | Result | Suite | Killed by |
| --- | --- | --- | --- | --- |
| M0 | none (baseline) | — | 315 passed / 0 failed | — |
| M1 | accessor reads `IOwnable.owner.selector` instead of `IBeacon.implementation.selector` | **KILLED** | 310 / 5 | `testReadsImplementationNotOwner`, `testReturnsImplementation`, `testReturnsZeroImplementation`, `testReturnsMaxAddressImplementation`, `testComposesWithMetamorphicCheck` |
| M2 | accessor forces `ok = true`, keeps the address | **KILLED** | 309 / 6 | all six `testFalseOn*` |
| M3 | accessor keeps `ok`, always returns `address(0)` | **KILLED** | 311 / 4 | `testReturnsImplementation`, `testReadsImplementationNotOwner`, `testReturnsMaxAddressImplementation`, `testComposesWithMetamorphicCheck` (no longer reverts) |
| M4 | accessor returns `address(uint160(a) + 1)` | **KILLED** | 304 / 11 | every address assertion, incl. `testReturnsMaxAddressImplementation` by overflow panic |
| M5 | ramification: `isBeaconImplementationBytecode` rewired to the `owner()` selector (the risk the duplicated expression creates) | **KILLED** | 312 / 3 | `testMatches`, `testMatchesAtMaxAddressBoundary`, `testImplementationZeroAddressHashesToEmpty` |
| M6 | ramification: `isBeaconImplementationBytecode` drops the `ok &&` guard | **KILLED** | 308 / 7 | all seven `testReturnsFalseOn*` |

6 mutants, 6 killed, 0 survived.

Logs: `/home/gildlab/artifacts/2026-08-18-extro-issues/i-82/.scratch/mutations/`.

## QA
- Discriminating tests: `testReturnsImplementation`, `testReadsImplementationNotOwner`, `testReturnsZeroImplementation`, `testReturnsMaxAddressImplementation`, `testFalseOnNonBeacon`, `testFalseOnRevert`, `testFalseOnDirtyAddress`, `testFalseOnWrongLengthReturn`, `testFalseOnNoCodeTarget`, `testFalseOnRevertWithAddressSizedData`, `testComposesWithMetamorphicCheck` - each fails on base by construction: `LibExtrospectERC1967BeaconProxy.beaconImplementation` does not exist at `32f7325`, so the file does not compile there (verified: an early mutation run restored the library to the base version while keeping the new test file, giving `rc=1` with no suite run at all - which is why the branch baseline had to be committed before mutating).
- Mutations applied: `beaconImplementation` selector arg -> `IOwnable.owner.selector` -> killed by `testReadsImplementationNotOwner` +4; `beaconImplementation` return -> force `ok=true` -> killed by all six `testFalseOn*`; `beaconImplementation` return -> always `address(0)` -> killed by `testReturnsImplementation` +3; `beaconImplementation` return -> `address(uint160(a)+1)` -> killed by 11 tests; `isBeaconImplementationBytecode` selector arg -> `IOwnable.owner.selector` -> killed by `testMatches` +2; `isBeaconImplementationBytecode` -> drop the `ok &&` guard -> killed by all seven `testReturnsFalseOn*`. 6 applied, 6 killed, 0 survived; per-run suite counts in the table above.
- Oracle: EIP-1967 and the `IBeacon` interface, not the implementation. The expected address is the value the test itself hands `MockBeacon`'s constructor; the expected failure modes are the four the ABI defines as undecodable (`staticcall` failure, absent selector, return length != 32, upper 12 bytes non-zero). `testComposesWithMetamorphicCheck` takes its oracle from a second, independent subsystem: `LibExtrospectMetamorphic.checkNotMetamorphic` must revert for `HasSelfdestruct` and must not for `NonMetamorphic`.
- Category check: issue asks (a) an accessor yielding the beacon's implementation address, (b) the same reachable through `IExtrospectV1`, (c) `check*` reverting twins for the two beacon predicates. Covered (a). (b) deferred - it moves a deterministic address that is live on three chains, so the option space is posted on the issue instead. (c) not done because the premise is false: four other `IExtrospectV1` entry points also ship without a reverting twin.
