### PR TITLE
Docs: describe the shipped surface, not the removed interfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-rain.extrospection is a Solidity library for analyzing EVM contract bytecode onchain. It provides opcode scanning (present vs. reachable), ERC1167 minimal proxy detection, ERC1967 beacon proxy extrospection, Solidity CBOR metadata trimming and hashing, and metamorphic risk detection. The libraries are exposed externally by one concrete contract, `Extrospect`, implementing `IExtrospectV1`. The library exposes onchain logic to offchain tooling — the algorithms are gas-intensive and primarily intended for offchain use.
+rain.extrospection is a Solidity library for analyzing EVM contract bytecode onchain. It provides opcode scanning (present vs. reachable), ERC1167 minimal proxy detection, ERC1967 beacon extrospection, Solidity CBOR metadata trimming, and metamorphic risk detection. The library exposes onchain logic to offchain tooling — the algorithms are gas-intensive and primarily intended for offchain use.
 
 License: LicenseRef-DCL-1.0 (DecentraLicense)
 
@@ -36,22 +36,13 @@ nix develop -c forge test --match-test testFoo
 
 ## Architecture
 
-**Source layout:** `src/lib/` for library implementations, `src/interface/` for interfaces, `src/concrete/` for the one deployed contract.
+**Key pattern:** Opcodes are encoded as a single `uint256` bitmap where bit N represents opcode 0xN. Bitwise AND against reference bitmaps checks for (un)desired opcodes in one operation. `EVMOpcodes` defines one `EVM_OP_*` constant per opcode defined through Cancun — 149 of the 256 byte values; the rest are unassigned.
 
-**Core libraries:**
-- `LibExtrospectBytecode` — Opcode scanning (present scan: linear pass respecting PUSH\* inline data; reachable scan: halt-aware with JUMPDEST tracking), CBOR metadata trimming and trimmed-hash checks, EOF detection
-- `LibExtrospectERC1167Proxy` — ERC1167 minimal proxy detection and implementation address extraction
-- `LibExtrospectERC1967BeaconProxy` — Beacon implementation-bytecode and owner checks, plus the ERC1967 slot constants
-- `LibExtrospectMetamorphic` — Metamorphic risk detection (scans for reachable SELFDESTRUCT, DELEGATECALL, CALLCODE, CREATE, CREATE2)
-- `EVMOpcodes` — One `EVM_OP_*` constant per opcode defined through Cancun (149 of the 256 byte values; the rest are unassigned) and derived bitmaps: `HALTING_BITMAP`, `METAMORPHIC_OPS`, `NON_STATIC_OPS`, `INTERPRETER_DISALLOWED_OPS`
+**Deploy pin:** `src/concrete/Extrospect.sol` is the one deployed contract and pins its own creation bytecode, deterministic Zoltu address and runtime codehash as constants. Any source change reaching it invalidates all three and supersedes the deployed address.
 
-**Concrete contract:** `Extrospect` implements `IExtrospectV1`, forwarding each function to the library function of the same name. Its constructor takes no arguments, and `Extrospect.sol` pins the creation bytecode, deterministic Zoltu address and runtime codehash as constants that `script/Deploy.sol` and `test/src/concrete/Extrospect.constants.t.sol` both read.
+**Orphaned bitmaps:** `NON_STATIC_OPS` and `INTERPRETER_DISALLOWED_OPS` have no consumer in `src/`. Only `test/src/lib/EVMOpcodes.t.sol` reads them, so they look load-bearing and are not.
 
-**Orphaned bitmaps:** `NON_STATIC_OPS` and `INTERPRETER_DISALLOWED_OPS` have no consumer in `src/` — no library, interface or deployed function reads them. They are exported for callers to mask against a reachable scan themselves, and only `test/src/lib/EVMOpcodes.t.sol` references them in-repo.
-
-**Key pattern:** Opcodes are encoded as a single `uint256` bitmap where bit N represents opcode 0xN. Bitwise AND against reference bitmaps checks for (un)desired opcodes in one operation.
-
-**Test layout:** `test/src/` mirrors source structure by subject path, so `test/src/lib/` covers `src/lib/` and `test/src/concrete/` covers `src/concrete/`. Test files named `Subject.functionName.t.sol`. `test/lib/` holds test-only libraries, including slow reference implementations (`LibExtrospectionSlow`) used for property-based fuzz verification, and `test/concrete/` holds test-only contracts used as fixtures.
+**Test layout:** `test/src/` mirrors `src/` by subject path. Test files named `Subject.functionName.t.sol`. `test/lib/` and `test/concrete/` are test-only helpers, including slow reference implementations (`LibExtrospectionSlow`) used for property-based fuzz verification.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-rain.extrospection is a Solidity library for analyzing EVM contract bytecode onchain. It provides opcode scanning (present vs. reachable), ERC1167 minimal proxy detection, Solidity CBOR metadata trimming, and interpreter safety validation. The library exposes onchain logic to offchain tooling — the algorithms are gas-intensive and primarily intended for offchain use.
+rain.extrospection is a Solidity library for analyzing EVM contract bytecode onchain. It provides opcode scanning (present vs. reachable), ERC1167 minimal proxy detection, ERC1967 beacon proxy extrospection, Solidity CBOR metadata trimming and hashing, and metamorphic risk detection. The libraries are exposed externally by one concrete contract, `Extrospect`, implementing `IExtrospectV1`. The library exposes onchain logic to offchain tooling — the algorithms are gas-intensive and primarily intended for offchain use.
 
 License: LicenseRef-DCL-1.0 (DecentraLicense)
 
@@ -36,17 +36,22 @@ nix develop -c forge test --match-test testFoo
 
 ## Architecture
 
-**Source layout:** `src/lib/` for library implementations. No concrete deployed contracts — libraries only.
+**Source layout:** `src/lib/` for library implementations, `src/interface/` for interfaces, `src/concrete/` for the one deployed contract.
 
 **Core libraries:**
-- `LibExtrospectBytecode` — Opcode scanning (present scan: linear pass respecting PUSH\* inline data; reachable scan: halt-aware with JUMPDEST tracking), CBOR metadata trimming, EOF detection
+- `LibExtrospectBytecode` — Opcode scanning (present scan: linear pass respecting PUSH\* inline data; reachable scan: halt-aware with JUMPDEST tracking), CBOR metadata trimming and trimmed-hash checks, EOF detection
 - `LibExtrospectERC1167Proxy` — ERC1167 minimal proxy detection and implementation address extraction
+- `LibExtrospectERC1967BeaconProxy` — Beacon implementation-bytecode and owner checks, plus the ERC1967 slot constants
 - `LibExtrospectMetamorphic` — Metamorphic risk detection (scans for reachable SELFDESTRUCT, DELEGATECALL, CALLCODE, CREATE, CREATE2)
-- `EVMOpcodes` — Constants for all 256 EVM opcodes and derived bitmaps (e.g. `HALTING_BITMAP`, `METAMORPHIC_OPS`)
+- `EVMOpcodes` — One `EVM_OP_*` constant per opcode defined through Cancun (149 of the 256 byte values; the rest are unassigned) and derived bitmaps: `HALTING_BITMAP`, `METAMORPHIC_OPS`, `NON_STATIC_OPS`, `INTERPRETER_DISALLOWED_OPS`
+
+**Concrete contract:** `Extrospect` implements `IExtrospectV1`, forwarding each function to the library function of the same name. Its constructor takes no arguments, and `Extrospect.sol` pins the creation bytecode, deterministic Zoltu address and runtime codehash as constants that `script/Deploy.sol` and `test/src/concrete/Extrospect.constants.t.sol` both read.
+
+**Orphaned bitmaps:** `NON_STATIC_OPS` and `INTERPRETER_DISALLOWED_OPS` have no consumer in `src/` — no library, interface or deployed function reads them. They are exported for callers to mask against a reachable scan themselves, and only `test/src/lib/EVMOpcodes.t.sol` references them in-repo.
 
 **Key pattern:** Opcodes are encoded as a single `uint256` bitmap where bit N represents opcode 0xN. Bitwise AND against reference bitmaps checks for (un)desired opcodes in one operation.
 
-**Test layout:** `test/src/lib/` mirrors source structure. Test files named `LibName.functionName.t.sol`. Test helpers in `test/lib/` include slow reference implementations (`LibExtrospectionSlow`) used for property-based fuzz verification.
+**Test layout:** `test/src/` mirrors source structure by subject path, so `test/src/lib/` covers `src/lib/` and `test/src/concrete/` covers `src/concrete/`. Test files named `Subject.functionName.t.sol`. `test/lib/` holds test-only libraries, including slow reference implementations (`LibExtrospectionSlow`) used for property-based fuzz verification, and `test/concrete/` holds test-only contracts used as fixtures.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,29 @@ Efforts have been made to implement the logic efficiently but it is expected tha
 the primary execution environment will be offchain, so there are somewhat gas
 intensive algorithms in this repository.
 
-### `IExtrospectBytecodeV2`
+### `IExtrospectV1` and `Extrospect`
 
-Tools to read and get a basic understanding of what opcodes are used in the
-bytecode of some address.
+`src/interface/IExtrospectV1.sol` is the external interface and
+`src/concrete/Extrospect.sol` is its implementation. `Extrospect` has a
+parameterless constructor and holds no state, so a single deployment serves every
+caller. Each of its functions forwards to the library function of the same name
+and does nothing else, so the interface is a call-and-return view of the
+libraries below.
 
-The most basic functions `bytecode` and `bytecodeHash` simply expose the
-underlying native evm logic for each.
+`src/interface/IBeacon.sol` and `src/interface/IOwnable.sol` are the minimal
+`implementation()` and `owner()` interfaces used to query beacons.
 
-The more sophisticated `scanEVMOpcodesPresentInAccount` and
-`scanEVMOpcodesReachableInAccount` build a bitmap of all the opcodes that are
-present in the scanned contract. This bitmap is built as `1 << opcode` where
-opcode is a single byte, and the scan is a `uint256` so the space of all opcodes
-as a `uint8` maps perfectly to all the bits in an EVM word.
+### Opcode scanning
+
+`LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode` and
+`LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode` build a bitmap of the
+opcodes found in the bytecode passed to them. This bitmap is built as
+`1 << opcode` where opcode is a single byte, and the scan is a `uint256` so the
+space of all opcodes as a `uint8` maps perfectly to all the bits in an EVM word.
+
+Both scans take bytecode as `bytes memory` rather than an address, so the caller
+chooses what to feed them: `account.code`, a constructor argument, or bytecode
+already trimmed by `tryTrimSolidityCBORMetadata`.
 
 The "present in" scan simply loops over the entire bytecode, but is `PUSH*` aware
 so knows that the inline argument to any `PUSH` opcode is not itself an opcode.
@@ -46,9 +56,31 @@ if the EVM execution model ever changes. For example, if the set of halting ops
 ever changes, or a new `JUMPDEST` alternative is invented, the scanner will
 require an entirely new implementation and redeployment to support this.
 
-### `IExtrospectERC1167ProxyV1`
+Both scans revert with `EOFBytecodeNotSupported` on EOF bytecode.
 
-Check if a given account is an `ERC1167` minimal proxy contract.
+### Bytecode hashing and Solidity CBOR metadata
+
+`LibExtrospectBytecode.tryTrimSolidityCBORMetadata` recognises the default
+Solidity CBOR metadata trailer and shortens the bytecode in place past it,
+reporting whether it trimmed.
+
+`checkCBORTrimmedBytecodeHash(account, expected)` trims an account's code and
+reverts unless the hash of what remains equals `expected`, so the comparison is
+against bytecode with the compiler's embedded metadata hash removed. It reverts
+with `MetadataNotTrimmed` when there was no metadata trailer to trim at all,
+before any hash comparison happens.
+
+`checkNoSolidityCBORMetadata(account)` is the inverse: it reverts when metadata
+is detected at all, for bytecode that was compiled with metadata disabled.
+
+`isEOFBytecode` and `checkNotEOFBytecode` report and enforce that bytecode is not
+EOF formatted.
+
+### ERC-1167 minimal proxies
+
+`LibExtrospectERC1167Proxy.isERC1167Proxy` checks whether bytecode is an
+`ERC1167` minimal proxy contract and extracts the implementation address it
+proxies.
 
 https://eips.ethereum.org/EIPS/eip-1167
 
@@ -58,23 +90,54 @@ account is a proxy and extract the implementation address that is being proxied.
 Having a canonical onchain check for this simplifies downstream tooling and
 minimises the surface area for implementation bugs.
 
-### `IExtrospectInterpreterV1`
+### ERC-1967 beacon proxies
 
-Check if a candidate interpreter contract is fundamentally UNSAFE due to
-mutation.
+`LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode` calls
+`implementation()` on a beacon and compares the runtime bytecode hash of the
+answer against an expected hash. `isBeaconOwner` calls `owner()` on a beacon and
+compares the answer against an expected owner. Both return `false` rather than
+reverting when the call fails for any reason, including the target not being a
+beacon at all.
+
+The same file exports `ERC1967_IMPLEMENTATION_SLOT`, `ERC1967_ADMIN_SLOT` and
+`ERC1967_BEACON_SLOT`, derived in source from the EIP-1967 formula. ERC-1967
+specifies those slots but no getter for them, so reading a proxy's beacon slot
+needs storage access that a runtime contract context does not have.
+
+### Metamorphic risk
+
+`LibExtrospectMetamorphic.scanMetamorphicRisk` masks the reachable opcode scan
+against `METAMORPHIC_OPS` and returns the risky opcodes that are reachable.
+`checkNotMetamorphic` reverts with `Metamorphic(riskyOpcodes)` when that result
+is non-zero.
 
 One fundamental hard requirement of an interpreter is that it is NOT mutable.
 Most obviously this includes `SELFDESTRUCT` as that would allow for things like
 metamorphic languages, which would completely undermine the integrity of any
-expression that runs on the interpreter.
+expression that runs on the interpreter. `METAMORPHIC_OPS` covers `SELFDESTRUCT`,
+`DELEGATECALL`, `CALLCODE`, `CREATE` and `CREATE2`.
 
-Less obviously, every opcode that would fail a standard static call is also
-disallowed within interpreters. This gives interpreters a guaranteed familiar
-set of security guarantees without needing to consider their internal
-implementation.
+### `EVMOpcodes` constants
 
-Pragmatically this is a thin wrapper around the bytecode scanning tools that
-check for reachability of dangerous opcodes in the underlying.
+`src/lib/EVMOpcodes.sol` defines one `EVM_OP_*` constant per opcode defined
+through Cancun — 149 of them. The other 107 of the 256 byte values are not
+assigned opcodes and so have no constant, while the scan bitmaps still cover all
+256 bit positions.
 
-This interface and/or concrete implementations are subject to change if/when new
-opcodes are supported by the EVM due to future hard forks.
+The derived bitmaps are:
+
+- `HALTING_BITMAP` — opcodes that terminate the current execution path, used by
+  the reachable scan.
+- `METAMORPHIC_OPS` — opcodes that indicate metamorphic risk, used by
+  `LibExtrospectMetamorphic`.
+- `NON_STATIC_OPS` — opcodes disallowed in a static context per EIP-214.
+- `INTERPRETER_DISALLOWED_OPS` — `NON_STATIC_OPS` plus `SLOAD`, `TLOAD`,
+  `DELEGATECALL` and `CALLCODE`.
+
+`NON_STATIC_OPS` and `INTERPRETER_DISALLOWED_OPS` are exported constants only. No
+library, no `IExtrospectV1` function and no deployed contract in this repository
+reads either of them. A caller wanting an interpreter safety check masks a
+reachable scan against `INTERPRETER_DISALLOWED_OPS` itself.
+
+The opcode constants, and the bitmaps derived from them, are subject to change
+if/when new opcodes are supported by the EVM due to future hard forks.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/88

## What was wrong

Verified all five claims against `main` @ `32f7325`.

| Claim | Verified |
| --- | --- |
| `IExtrospectBytecodeV2`, `IExtrospectERC1167ProxyV1`, `IExtrospectInterpreterV1` do not exist | Yes. `src/interface/` is `IBeacon.sol`, `IExtrospectV1.sol`, `IOwnable.sol`. Deleted in `67eca86`. |
| `bytecode`, `bytecodeHash`, `scanEVMOpcodesPresentInAccount`, `scanEVMOpcodesReachableInAccount`, `scanOnlyAllowedInterpreterEVMOpcodes` do not exist | Yes. Zero hits outside `README.md`. The scans are `scanEVMOpcodes{Present,Reachable}InBytecode` and take `bytes memory`, not an address. |
| `src/concrete/Extrospect.sol` contradicts "No concrete deployed contracts — libraries only" | Yes. `Extrospect` ships, with a pinned Zoltu address and runtime codehash. |
| `EVMOpcodes.sol` defines 149 opcode constants, not 256 | Yes. 149 constants, 149 distinct values, covering every opcode defined through Cancun (`0x00-0x0B`, `0x10-0x1D`, `0x20`, `0x30-0x3F`, `0x40-0x4A`, `0x50-0x5F`, `0x60-0x7F`, `0x80-0x8F`, `0x90-0x9F`, `0xA0-0xA4`, `0xF0-0xF5`, `0xFA`, `0xFD`, `0xFE`, `0xFF`). The other 107 byte values are unassigned. |
| `NON_STATIC_OPS` and `INTERPRETER_DISALLOWED_OPS` have no consumer in `src/` | Yes. Only `EVMOpcodes.sol` itself (definition + header) and `test/src/lib/EVMOpcodes.t.sol`. |

One correction to the issue: the orphaned bitmaps carry **10** test functions, not ~60 — `testNonStaticOps`, `testNonStaticOpsIndividualBits`, `testNonStaticOpsExclusions`, `testNonStaticOpsPopcount`, `testInterpreterDisallowedOps`, `testInterpreterDisallowedOpsIndividualBits`, `testInterpreterDisallowedOpsExclusions`, `testInterpreterDisallowedOpsPopcount`, `testInterpreterDisallowedOpsIsSupersetOfNonStaticOps`, `testMetamorphicOpsIsSubsetOfInterpreterDisallowedOps`. `EVMOpcodes.t.sol` has 19 test functions total.

## What this PR does

Decision (a) from the issue's triage only: the docs now describe the shipped surface.

`README.md` — the three dead interface sections are replaced by sections for what is in the tree: `IExtrospectV1`/`Extrospect`, opcode scanning, CBOR metadata and bytecode hashing, ERC-1167, ERC-1967 beacons, metamorphic risk, and the `EVMOpcodes` constants. The prose describing how the present and reachable scans behave was already correct and is kept verbatim; only the names around it changed.

`CLAUDE.md` — both false claims lived in the **Source layout** line and the **Core libraries** list. The rainix static job caps agent context at 4096 bytes and its ruling names directory layouts, dependency lists and architecture overviews as discoverable and directs cutting them, so rather than correcting an architecture overview the README now carries in full, both are removed. What replaces them is the part not recoverable by reading a file the task already points at: the deploy-constant pin on `src/concrete/Extrospect.sol` (any source change reaching it invalidates the pinned creation bytecode, Zoltu address and runtime codehash, and supersedes the deployed address), the orphaned bitmaps, the corrected 149-of-256 opcode count folded into the bitmap paragraph, and a test-layout line that covers `test/src/concrete/` and `test/concrete/` as well. CLAUDE.md ends at 3358 bytes, below main's 3392.

The first push of this branch expanded that section instead and failed the cap at 4680 bytes; `58bdebd` is the fix.

Both files now state plainly that `NON_STATIC_OPS` and `INTERPRETER_DISALLOWED_OPS` are exported constants with no consumer in this repository, so the orphan is on the record rather than deleted out of the docs.

## What this PR deliberately does not do

Decision (b) — whether the interpreter-safety capability is intentionally dropped (delete both bitmaps and their 10 tests) or meant to return (add a check that consumes them) — changes what this library concludes about a contract, so it is not decided here. The option space, with what each option newly accepts or rejects and the deployed-address cost of one of them, is posted as a comment on issue #88 for a human ruling. Whichever way it is ruled is a source change this PR does not make and needs its own issue.

## Test evidence

No `.sol` file is touched by this PR, so there is no mutant surface and no mutation table: every mutation of every source line produces exactly the same result before and after this diff. What is proven instead is that the suite ran and is unchanged.

Baseline, `main` @ `32f7325`:

```
Ran 27 test suites in 501.69ms (5.91s CPU time): 311 tests passed, 3 failed, 0 skipped (314 total tests)
```

This branch, `c221a0f` (the docs commit; `58bdebd` touches only CLAUDE.md and cannot move it):

```
Ran 27 test suites in 558.35ms (5.59s CPU time): 311 tests passed, 3 failed, 0 skipped (314 total tests)
```

The 3 failures are identical in both runs and are all `vm.createSelectFork: environment variable ARBITRUM_RPC_URL not found` in `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` (`testCheckCBORTrimmedBytecodeHashSuccess`, `testCheckCBORTrimmedBytecodeHashFailure`, `testCheckCBORTrimmedBytecodeHashMetadataNotTrimmed`) — the fork-RPC dependency that issue #85 is about. `ExtrospectConstantsTest` ran and passed in both, so the pinned deploy constants are unaffected.

`nix develop -c forge fmt --check` is clean.

## QA
- Discriminating tests: n/a - a docs-only diff has no behaviour to discriminate on, and the standing ruling forbids tests that read or assert prose (README, NatSpec, any doc file). Every claim the docs now make was instead verified by grep/count against the tree at `32f7325`, transcribed in the table above.
- Mutations applied: n/a - zero `.sol` files are touched, so there is no line to mutate that this diff could change the killing set of. Established for this repo today and not re-run: `ExtrospectConstantsTest` pins deployed bytecode and so dies under every source mutation, meaning any filter including it reports KILLED for every mutant and measures nothing.
- Oracle: the source tree itself, read independently of the docs. `ls src/interface/`; `grep -rn` for each of the five function names the README claimed; `grep -c '^uint8 constant EVM_OP_'` = 149 and `sort -u` on the values = 149 distinct, checked against the opcode ranges defined through Cancun; `grep -rn 'NON_STATIC_OPS\|INTERPRETER_DISALLOWED_OPS' src/ script/` returning only the definitions and the file's own header comment.
- Category check: issue asks (a) update the docs to the shipped surface, (b) rule on whether the interpreter-safety capability is dropped or returning. Covered (a). (b) is excluded on purpose - it changes what the library concludes about a contract, so the option space is posted on the issue for a human ruling instead, and whichever way it is ruled becomes its own issue, since it is a source change this PR does not make.
