### PR TITLE
Split fork tests out of checkCBORTrimmedBytecodeHash unit tests

### DIFF
--- a/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.fork.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.fork.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibExtrospectTestProd} from "test/lib/LibExtrospectTestProd.sol";
+import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
+
+/// Every test in this contract forks Arbitrum and so requires
+/// `ARBITRUM_RPC_URL`. The tests of `checkCBORTrimmedBytecodeHash` that run
+/// without a fork live in
+/// `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol`.
+contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashForkTest is Test {
+    address constant PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1 = address(0xe01Db32B1E03976b24e3A948A560f4b97Dd732dA);
+    bytes32 constant PROD_ARBITRUM_CLONE_FACTORY_CODEHASH_V1 =
+        bytes32(0x7b085ca3e5c659da29caf26d23e7b72fd4fdbc59aa6b5611cf3918c4586ec73a);
+
+    function externalCheckCBORTrimmedBytecodeHash(address target, bytes32 expectedCodeHash) external view {
+        LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(target, expectedCodeHash);
+    }
+
+    function testCheckCBORTrimmedBytecodeHashSuccess() external {
+        LibExtrospectTestProd.createSelectForkArbitrum(vm);
+
+        LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(
+            PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1, PROD_ARBITRUM_CLONE_FACTORY_CODEHASH_V1
+        );
+    }
+
+    function testCheckCBORTrimmedBytecodeHashFailure() external {
+        bytes32 expectedCodeHash = bytes32(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
+        LibExtrospectTestProd.createSelectForkArbitrum(vm);
+
+        bytes32 actualCodeHash = PROD_ARBITRUM_CLONE_FACTORY_CODEHASH_V1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibExtrospectBytecode.BytecodeHashMismatch.selector, expectedCodeHash, actualCodeHash
+            )
+        );
+        this.externalCheckCBORTrimmedBytecodeHash(PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1, expectedCodeHash);
+    }
+
+    function testCheckCBORTrimmedBytecodeHashMetadataNotTrimmed() external {
+        bytes32 expectedCodeHash = bytes32(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
+        LibExtrospectTestProd.createSelectForkArbitrum(vm);
+
+        // Use an account that does not have Solidity CBOR metadata and is
+        // therefore not trimmed.
+        // This is a deployed rain interpreter contract.
+        address accountWithoutMetadata = address(0x1Bd4F25881B5A82302Edc07FCa994faa21baec7F);
+
+        // The code hash does not matter because the error for trimming happens
+        // before the hash is checked.
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.MetadataNotTrimmed.selector));
+        this.externalCheckCBORTrimmedBytecodeHash(accountWithoutMetadata, expectedCodeHash);
+    }
+}

--- a/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
@@ -43,6 +43,11 @@ contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
         bytes memory withMetadata =
             bytes.concat(code, hex"a264697066735822", ipfsHash, hex"64736f6c6343", solcVersion, hex"0033");
 
+        // vm.etch treats bytecode whose first two bytes are 0xef01 as an
+        // EIP-7702 delegation designator and rejects it unless it is exactly
+        // 23 bytes. withMetadata is always at least 53 bytes.
+        vm.assume(uint8(withMetadata[0]) != 0xEF || uint8(withMetadata[1]) != 0x01);
+
         // Compute the expected trimmed hash (hash of code without metadata).
         bytes32 expectedHash = keccak256(code);
 
@@ -76,6 +81,11 @@ contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
         vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
         // Ensure the code does not already contain valid CBOR metadata.
         vm.assume(!LibExtrospectBytecode.tryTrimSolidityCBORMetadata(code));
+
+        // vm.etch treats bytecode whose first two bytes are 0xef01 as an
+        // EIP-7702 delegation designator and rejects it unless it is exactly
+        // 23 bytes.
+        vm.assume(code.length < 2 || code.length == 23 || uint8(code[0]) != 0xEF || uint8(code[1]) != 0x01);
 
         address target = address(0xBEEF);
         vm.etch(target, code);

--- a/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
@@ -3,38 +3,15 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibExtrospectTestProd} from "test/lib/LibExtrospectTestProd.sol";
 import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
 
+/// No test in this contract forks, so every test here runs without any RPC
+/// environment variable. The tests of `checkCBORTrimmedBytecodeHash` that fork
+/// Arbitrum live in
+/// `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.fork.t.sol`.
 contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
-    address constant PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1 = address(0xe01Db32B1E03976b24e3A948A560f4b97Dd732dA);
-    bytes32 constant PROD_ARBITRUM_CLONE_FACTORY_CODEHASH_V1 =
-        bytes32(0x7b085ca3e5c659da29caf26d23e7b72fd4fdbc59aa6b5611cf3918c4586ec73a);
-
     function externalCheckCBORTrimmedBytecodeHash(address target, bytes32 expectedCodeHash) external view {
         LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(target, expectedCodeHash);
-    }
-
-    function testCheckCBORTrimmedBytecodeHashSuccess() external {
-        LibExtrospectTestProd.createSelectForkArbitrum(vm);
-
-        LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(
-            PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1, PROD_ARBITRUM_CLONE_FACTORY_CODEHASH_V1
-        );
-    }
-
-    function testCheckCBORTrimmedBytecodeHashFailure() external {
-        bytes32 expectedCodeHash = bytes32(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
-        LibExtrospectTestProd.createSelectForkArbitrum(vm);
-
-        bytes32 actualCodeHash = PROD_ARBITRUM_CLONE_FACTORY_CODEHASH_V1;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                LibExtrospectBytecode.BytecodeHashMismatch.selector, expectedCodeHash, actualCodeHash
-            )
-        );
-        this.externalCheckCBORTrimmedBytecodeHash(PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1, expectedCodeHash);
     }
 
     /// Test that an empty account (no deployed code) reverts with
@@ -42,21 +19,6 @@ contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
     function testCheckCBORTrimmedBytecodeHashEmptyAccount() external {
         vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.MetadataNotTrimmed.selector));
         this.externalCheckCBORTrimmedBytecodeHash(address(0xdead), bytes32(0));
-    }
-
-    function testCheckCBORTrimmedBytecodeHashMetadataNotTrimmed() external {
-        bytes32 expectedCodeHash = bytes32(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
-        LibExtrospectTestProd.createSelectForkArbitrum(vm);
-
-        // Use an account that does not have Solidity CBOR metadata and is
-        // therefore not trimmed.
-        // This is a deployed rain interpreter contract.
-        address accountWithoutMetadata = address(0x1Bd4F25881B5A82302Edc07FCa994faa21baec7F);
-
-        // The code hash does not matter because the error for trimming happens
-        // before the hash is checked.
-        vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.MetadataNotTrimmed.selector));
-        this.externalCheckCBORTrimmedBytecodeHash(accountWithoutMetadata, expectedCodeHash);
     }
 
     /// Fuzz test: etch bytecode with valid CBOR metadata onto an address,

--- a/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
@@ -51,6 +51,11 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
         vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
         vm.assume(!LibExtrospectBytecode.tryTrimSolidityCBORMetadata(code));
 
+        // vm.etch treats bytecode whose first two bytes are 0xef01 as an
+        // EIP-7702 delegation designator and rejects it unless it is exactly
+        // 23 bytes.
+        vm.assume(code.length < 2 || code.length == 23 || uint8(code[0]) != 0xEF || uint8(code[1]) != 0x01);
+
         address target = address(0xBEEF);
         vm.etch(target, code);
         LibExtrospectBytecode.checkNoSolidityCBORMetadata(target);
@@ -74,6 +79,11 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
 
         bytes memory withMetadata =
             bytes.concat(code, hex"a264697066735822", ipfsHash, hex"64736f6c6343", solcVersion, hex"0033");
+
+        // vm.etch treats bytecode whose first two bytes are 0xef01 as an
+        // EIP-7702 delegation designator and rejects it unless it is exactly
+        // 23 bytes. withMetadata is always at least 53 bytes.
+        vm.assume(uint8(withMetadata[0]) != 0xEF || uint8(withMetadata[1]) != 0x01);
 
         address target = address(0xBEEF);
         vm.etch(target, withMetadata);


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/85

## What changed

Test file split only. No source change, no test body change, no assertion change, no
verdict change — every test that existed before exists after, byte-identical in body.

`test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` held 7 tests, 3
of which call `LibExtrospectTestProd.createSelectForkArbitrum(vm)`. Excluding that path
to run without `ARBITRUM_RPC_URL` therefore dropped all 7.

The 3 fork tests move to
`test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.fork.t.sol`, together
with the two `PROD_ARBITRUM_CLONE_FACTORY_*` constants they are the only users of. The 4
non-fork tests stay where they were. Each file names the other in a comment, so the
fork/non-fork boundary is stated where a reader lands.

The exclusion needed to run locally is now exactly the fork set:

```
nix develop -c forge test --no-match-path 'test/**/*.fork.t.sol'
```

CI is unaffected: it has `ARBITRUM_RPC_URL` and runs all 314.

## Verified against main first

Reproduced on a fresh clone of `main` before touching anything. The issue's numbers were
taken at `28017b6` and `main` has since grown to 314 tests, but the defect is unchanged:

| command, on `main` | result |
|---|---|
| `forge test` | 311 passed, **3 failed** — all 3 `environment variable ARBITRUM_RPC_URL not found` |
| `forge test --no-match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'` | 307 passed, 0 failed |

314 − 307 = 7 tests dropped to silence 3 failures. 4 tests of collateral damage, exactly
as filed.

## Test counts

| command | before | after |
|---|---|---|
| full suite, with RPC | 314 | 314 |
| full suite, no RPC | 311 passed / 3 failed | 311 passed / 3 failed |
| local exclusion, no RPC | 307 passed / 0 failed | **311 passed / 0 failed** |

The 4 recovered tests are `testCheckCBORTrimmedBytecodeHashEmptyAccount`,
`testCheckCBORTrimmedBytecodeHashEOF`, `testCheckCBORTrimmedBytecodeHashFuzz` and
`testCheckCBORTrimmedBytecodeHashNoMetadataFuzz`.

## Adversarial mutation pass

10 mutants in `src/lib/LibExtrospectBytecode.sol`, each applied by line number with an
applied-or-abort checksum assertion, each run under three filters:

- **A** — the old local command: `--no-match-path '{test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash*.t.sol,test/src/concrete/Extrospect.constants.t.sol}'` → **304 tests** (the 7 dropped, as before this PR)
- **B** — the new local command: `--no-match-path '{test/**/*.fork.t.sol,test/src/concrete/Extrospect.constants.t.sol}'` → **308 tests** (only the 3 fork tests dropped)
- **C** — the 4 recovered tests alone: `--match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'` → **4 tests**

`Extrospect.constants.t.sol` is excluded from all three: it pins deployed bytecode and so
fails under every source mutation, which would report KILLED for every mutant and measure
nothing. The counts above are the proof the tests ran — a run that compiled but selected
nothing, or failed to compile, is reported as such rather than as SURVIVED.

Unmutated baseline: A 304 passed / 0 failed, B 308 passed / 0 failed, C 4 passed / 0
failed.

| # | mutant | A (old local cmd) | B (new local cmd) | C (recovered 4 alone) |
|---|---|---|---|---|
| M1 | L131 `if (!didTrim)` → `if (false)` — drop `MetadataNotTrimmed` guard | KILLED, 1 fail | KILLED, 3 fail | KILLED, 2 fail |
| M2 | L131 `if (!didTrim)` → `if (didTrim)` — invert guard | KILLED, 3 fail | KILLED, 6 fail | KILLED, 3 fail |
| M3 | L134 `actual = keccak256(bytecode)` → `actual = expected` — hash never compared | KILLED, 1 fail | KILLED, 2 fail | KILLED, 1 fail |
| M4 | L135 `if (expected != actual)` → `if (false)` — drop mismatch guard | KILLED, 1 fail | KILLED, 2 fail | KILLED, 1 fail |
| M5 | L136 `BytecodeHashMismatch(expected, actual)` → `(actual, expected)` — swapped args | KILLED, 1 fail | KILLED, 2 fail | KILLED, 1 fail |
| M6 | L129 `bytecode = account.code` → `bytecode = hex""` — wrong bytecode read | KILLED, 2 fail | KILLED, 4 fail | KILLED, 2 fail |
| M7 | L97 delete `checkNotEOFBytecode(bytecode)` in `tryTrimSolidityCBORMetadata` | KILLED, 2 fail | KILLED, 3 fail | KILLED, 1 fail |
| **M8** | **L131 `if (!didTrim)` → `if (!didTrim && bytecode.length > 0)` — guard skipped for zero-code accounts** | **SURVIVED** | **KILLED, 1 fail** | **KILLED, 1 fail** |
| M9 | L114 `sub(length, 53)` → `sub(length, 52)` — off-by-one trim | KILLED, 3 fail | KILLED, 4 fail | KILLED, 1 fail |
| M10 | L97 `checkNotEOFBytecode(bytecode)` → guarded by `bytecode.length > 5` | KILLED, 2 fail | KILLED, 3 fail | KILLED, 1 fail |

Two things the matrix establishes.

**The recovered tests are the whole delta.** In all 10 rows, `B fails = A fails + C fails`
exactly. The 4 tests this PR puts back into the local run are load-bearing coverage, not
duplicates of what already ran.

**M8 is the hole the old exclusion could not see.** An account with no deployed code
reaches `keccak256("")`; M8 lets exactly that case past the `MetadataNotTrimmed` guard
and nothing else changes. Under the old local command the entire 304-test suite passes
with that hole in place. Under the new one it fails immediately, on
`testCheckCBORTrimmedBytecodeHashEmptyAccount` — one of the four tests that the coarse
exclusion was discarding. This is the concrete instance of the issue's claim that the
empty-account path was being measured at zero.

**What the matrix also corrects.** The issue reads as though all four dropped paths were
unmeasured. M1–M7 and M9–M10 are all killed under the old command too, by
`test/src/concrete/Extrospect.checkCBORTrimmedBytecodeHash.t.sol` and
`test/src/lib/LibExtrospectBytecode.tryTrimSolidityCBORMetadata.t.sol`, which the coarse
exclusion never touched. The trim guard, the hash guard and the argument order were
covered by siblings; the zero-code-account case was the one genuinely uncovered.

Reproduce: `.scratch/mutate.sh` and `.scratch/mutate2.sh` under
`/home/gildlab/artifacts/2026-08-18-extro-issues/i-85/` (not committed).

## Second commit: a pre-existing CI flake this PR tripped over

The first CI run on this branch went red on `testCheckCBORTrimmedBytecodeHashFuzz` and
`testCheckCBORTrimmedBytecodeHashNoMetadataFuzz`:

```
[FAIL: vm.etch: failed to create bytecode: Eip7702 is not 23 bytes long;
 counterexample: args=[0xef01f1edde…, …]]
```

Not caused by the split — those two test bodies are byte-identical to `main`'s and the
failure is fuzz-seed dependent. `main`'s own last `rainix-sol` run (`32f73256`) is green
only because its seed did not draw these bytes.

Root cause: `vm.etch` reads bytecode whose **first two bytes are `0xef01`** as an EIP-7702
delegation designator and refuses it unless the code is exactly 23 bytes.
`isEOFBytecode` matches only the `0xEF00` EOF magic, so `0xef01…` passes
`vm.assume(!isEOFBytecode(code))` and then blows up inside the cheatcode. Nothing about
the library is wrong — a real 7702 account has 23 bytes of code, 23 < 53, so
`tryTrimSolidityCBORMetadata` returns false and `checkCBORTrimmedBytecodeHash` reverts
`MetadataNotTrimmed`, which is correct.

The exact rule was pinned by probe rather than assumed, on the same toolchain:

| etched bytes | result |
|---|---|
| `0xef01` + 89 more bytes (the CI counterexample) | rejected |
| `0xef01ff` + 21 more (third byte not `00`) | rejected |
| `0xef01` (2 bytes total) | rejected |
| `0xef0100` + 20-byte address (23 bytes) | accepted |
| `0xef02` + 22 more | accepted |
| `0xef` (1 byte total) | accepted |

So the predicate is exactly "first two bytes `0xef01` and length ≠ 23", and the added
`vm.assume` is that and nothing wider — 23-byte designators are still drawn and etched
where the test etches `code` directly.

Applied at all four sites in the repo that etch fuzz-derived bytecode, not just the two
that happened to fail: the other two are `testCheckNoMetadataPassesFuzz` and
`testCheckNoMetadataRevertsFuzz` in
`test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol`, which have the
identical `isEOFBytecode`-only guard in front of the identical `vm.etch`. The fuzzer
plainly carries `0xef01` in its corpus — it found it at run ~805 and hit both tests in the
one file with the same input — so leaving those two would have re-reddened this PR on a
later seed. Flagging them without fixing them would have been the same defect named twice.

Where the two tests append metadata, the etched value is `code ++ 53 bytes`, so it can
never be the 23-byte designator and the assume there carries no length clause.
## QA
- Discriminating tests: `testCheckCBORTrimmedBytecodeHashEmptyAccount`, `testCheckCBORTrimmedBytecodeHashEOF`, `testCheckCBORTrimmedBytecodeHashFuzz`, `testCheckCBORTrimmedBytecodeHashNoMetadataFuzz` — these four ARE the change. No test is added or modified; the discriminator is that they now run under the local no-RPC command. Verified on base: `forge test --no-match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'` on `main` selects 307 of 314 tests and excludes all four; after this PR `--no-match-path 'test/**/*.fork.t.sol'` selects 311 and includes all four. Against mutant M8 the base command reports 304 passed / 0 failed and the new command 307 passed / 1 failed.
- Mutations applied: 10 mutants in `src/lib/LibExtrospectBytecode.sol`, full matrix above. L131 `if (!didTrim)` → `if (!didTrim && bytecode.length > 0)` (M8) → survives the base local command's entire 304-test suite, killed by `testCheckCBORTrimmedBytecodeHashEmptyAccount`. L131 → `if (false)` and → `if (didTrim)`; L134 `keccak256(bytecode)` → `expected`; L135 `expected != actual` → `false`; L136 swapped `BytecodeHashMismatch` args; L129 `account.code` → `hex""`; L97 `checkNotEOFBytecode` deleted, and separately length-guarded; L114 `sub(length, 53)` → `sub(length, 52)` → all killed under both commands. In every one of the 10 rows `B failures = A failures + C failures`, so the four recovered tests account for the entire delta. `test/src/concrete/Extrospect.constants.t.sol` is excluded from every mutation run: it pins deployed bytecode and fails under any source mutation, which would report KILLED for every mutant and measure nothing.
- Oracle: the issue, plus the pre-existing test bodies, which commit 1 leaves unchanged. Expected test membership comes from `grep -c 'function test'` (7) and `grep -c 'createSelectForkArbitrum'` (3) on the base file, not from the runner. Expected counts are arithmetic on the base total: 314 − 7 = 307 under the old command, 314 − 3 = 311 under the new one; both observed exactly. M8's expected behaviour is derived from reading `checkCBORTrimmedBytecodeHash` — a zero-code account has nothing to trim, so it must revert `MetadataNotTrimmed` — not from what the code does.
- Category check: issue asks for one thing, that the local exclusion be exactly the fork set so the four non-fork tests keep running without `ARBITRUM_RPC_URL`, and prescribes the split into `*.fork.t.sol`. Covered by commit 1, which moves tests and changes nothing else. Commit 2 is not the issue's ask — it is the pre-existing CI flake this PR surfaced, fixed here rather than left to redden the branch. Neither commit changes any verdict the library reaches: no source file is touched, no assertion is altered, and the only test-input change narrows fuzz draws to the shape `vm.etch` accepts.
- Second commit, discriminating evidence: the exact CI counterexample bytes fail `vm.etch` on this toolchain before the fix (probed directly: `vm.etch: failed to create bytecode: Eip7702 is not 23 bytes long`) and are excluded by the added assume after it. The accept/reject boundary was established by six probes, tabled above, rather than inferred from the error string. No mutants for that commit: it adds `vm.assume` guards to test inputs and touches no source line, so there is nothing to mutate that the first commit's matrix does not already cover.
