### PR TITLE
Guard fuzz-derived vm.etch against EIP-7702-shaped bytes

### DIFF
--- a/test/lib/LibExtrospectTestEtch.sol
+++ b/test/lib/LibExtrospectTestEtch.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+
+library LibExtrospectTestEtch {
+    /// True when `vm.etch` accepts `code` as account code.
+    ///
+    /// `vm.etch` reads any `code` prefixed `0xEF01` as an EIP-7702 delegation
+    /// designator and accepts it only when it is exactly 23 bytes long with a
+    /// zero version byte at index 2. Every other `code`, including the `0xEF00`
+    /// EOF prefix and a bare `0xEF`, is accepted as legacy bytecode.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function etchAcceptsEIP7702(bytes memory code) internal pure returns (bool) {
+        if (code.length >= 2 && code[0] == 0xEF && code[1] == 0x01) {
+            return code.length == 23 && code[2] == 0x00;
+        }
+        return true;
+    }
+
+    /// Etches `code` at `target`, rejecting the run when `vm.etch` would not
+    /// accept `code`. Fuzz-derived bytes reach `vm.etch` through this function
+    /// so that a rejected `code` discards the run instead of failing the test.
+    function assumeEtch(Vm vm, address target, bytes memory code) internal {
+        vm.assume(etchAcceptsEIP7702(code));
+        vm.etch(target, code);
+    }
+}

--- a/test/lib/LibExtrospectTestEtch.t.sol
+++ b/test/lib/LibExtrospectTestEtch.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibExtrospectTestEtch} from "test/lib/LibExtrospectTestEtch.sol";
+
+contract LibExtrospectTestEtchTest is Test {
+    address constant TARGET = address(0xBEEF);
+
+    /// The 33 byte counterexample foundry produced for the CBOR metadata fuzz
+    /// tests before they routed their etches through `assumeEtch`.
+    bytes constant COUNTEREXAMPLE = hex"ef01e8ca4630bc62619fd019a890e4de496295ee3586eebdb070893a2228228150";
+
+    /// A well formed EIP-7702 delegation designator: `0xef0100` then 20 address
+    /// bytes.
+    bytes constant DESIGNATOR = hex"ef01001234567890123456789012345678901234567890";
+
+    /// External wrapper so a rejected run is observable as revert data.
+    function assumeEtchExternal(address target, bytes memory code) external {
+        LibExtrospectTestEtch.assumeEtch(vm, target, code);
+    }
+
+    /// Asserts the predicate says `expected` and that `vm.etch` agrees.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function checkEtchAccepts(bytes memory code, bool expected) internal {
+        assertEq(LibExtrospectTestEtch.etchAcceptsEIP7702(code), expected, "predicate");
+        (bool ok,) = address(vm).call(abi.encodeWithSignature("etch(address,bytes)", TARGET, code));
+        assertEq(ok, expected, "vm.etch");
+    }
+
+    function testEtchAcceptsEmpty() external {
+        checkEtchAccepts(hex"", true);
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchAcceptsBareEF() external {
+        checkEtchAccepts(hex"ef", true);
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchAcceptsEOFPrefix() external {
+        checkEtchAccepts(hex"ef00", true);
+        checkEtchAccepts(hex"ef00010203", true);
+        checkEtchAccepts(hex"ef00000000000000000000000000000000000000000000", true);
+    }
+
+    /// `0xEF` followed by anything other than `0x00` or `0x01`.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchAcceptsOtherEFPrefixes() external {
+        checkEtchAccepts(hex"ef02010203", true);
+        checkEtchAccepts(hex"efff010203", true);
+    }
+
+    function testEtchAcceptsLegacyBytecode() external {
+        checkEtchAccepts(hex"6080604052600080fd", true);
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchAcceptsEIP7702Designator() external {
+        assertEq(DESIGNATOR.length, 23);
+        checkEtchAccepts(DESIGNATOR, true);
+    }
+
+    /// `0xEF01` at exactly two bytes has no version byte and no address.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchRejectsEIP7702PrefixAlone() external {
+        checkEtchAccepts(hex"ef01", false);
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchRejectsEIP7702PrefixTooShort() external {
+        checkEtchAccepts(hex"ef01010203", false);
+        checkEtchAccepts(hex"ef01093be21bc41c9151025546b30e304c0b4c", false);
+    }
+
+    /// 24 bytes: one byte longer than a designator.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchRejectsEIP7702PrefixTooLong() external {
+        bytes memory code = hex"ef0100123456789012345678901234567890123456789012";
+        assertEq(code.length, 24);
+        checkEtchAccepts(code, false);
+    }
+
+    /// 23 bytes with a non zero version byte.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchRejectsEIP7702BadVersion() external {
+        bytes memory code = hex"ef01991234567890123456789012345678901234567890";
+        assertEq(code.length, 23);
+        checkEtchAccepts(code, false);
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testEtchRejectsEIP7702Counterexample() external {
+        assertEq(COUNTEREXAMPLE.length, 33);
+        checkEtchAccepts(COUNTEREXAMPLE, false);
+    }
+
+    /// Accepted code is etched at the target.
+    function testAssumeEtchSetsCode() external {
+        bytes memory code = hex"6080604052600080fd";
+        LibExtrospectTestEtch.assumeEtch(vm, TARGET, code);
+        assertEq(TARGET.code, code);
+    }
+
+    /// An accepted `0xEF00` prefix is etched rather than rejected.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function testAssumeEtchSetsEOFCode() external {
+        bytes memory code = hex"ef00010203";
+        LibExtrospectTestEtch.assumeEtch(vm, TARGET, code);
+        assertEq(TARGET.code, code);
+    }
+
+    /// Rejected code discards the run through `vm.assume` instead of reaching
+    /// `vm.etch` and failing the test.
+    function testAssumeEtchRejectsRun() external {
+        (bool ok, bytes memory err) =
+            address(this).call(abi.encodeWithSelector(this.assumeEtchExternal.selector, TARGET, COUNTEREXAMPLE));
+        assertFalse(ok);
+        assertEq(err, bytes("FOUNDRY::ASSUME"));
+        assertEq(TARGET.code.length, 0);
+    }
+}

--- a/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol
@@ -5,6 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibExtrospectTestProd} from "test/lib/LibExtrospectTestProd.sol";
 import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
+import {LibExtrospectTestEtch} from "test/lib/LibExtrospectTestEtch.sol";
 
 contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
     address constant PROD_ARBITRUM_CLONE_FACTORY_ADDRESS_V1 = address(0xe01Db32B1E03976b24e3A948A560f4b97Dd732dA);
@@ -86,7 +87,7 @@ contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
 
         // Etch the bytecode onto an address.
         address target = address(0xBEEF);
-        vm.etch(target, withMetadata);
+        LibExtrospectTestEtch.assumeEtch(vm, target, withMetadata);
 
         // Correct hash should succeed.
         LibExtrospectBytecode.checkCBORTrimmedBytecodeHash(target, expectedHash);
@@ -116,7 +117,7 @@ contract LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest is Test {
         vm.assume(!LibExtrospectBytecode.tryTrimSolidityCBORMetadata(code));
 
         address target = address(0xBEEF);
-        vm.etch(target, code);
+        LibExtrospectTestEtch.assumeEtch(vm, target, code);
 
         vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.MetadataNotTrimmed.selector));
         this.externalCheckCBORTrimmedBytecodeHash(target, anyHash);

--- a/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
 import {NonMetamorphic} from "test/concrete/NonMetamorphic.sol";
 import {SOLIDITY_CBOR_RUNTIME_FIXTURE} from "test/concrete/SolidityCBORFixture.sol";
+import {LibExtrospectTestEtch} from "test/lib/LibExtrospectTestEtch.sol";
 
 contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
     /// External wrapper for revert tests.
@@ -52,7 +53,7 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
         vm.assume(!LibExtrospectBytecode.tryTrimSolidityCBORMetadata(code));
 
         address target = address(0xBEEF);
-        vm.etch(target, code);
+        LibExtrospectTestEtch.assumeEtch(vm, target, code);
         LibExtrospectBytecode.checkNoSolidityCBORMetadata(target);
     }
 
@@ -76,7 +77,7 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
             bytes.concat(code, hex"a264697066735822", ipfsHash, hex"64736f6c6343", solcVersion, hex"0033");
 
         address target = address(0xBEEF);
-        vm.etch(target, withMetadata);
+        LibExtrospectTestEtch.assumeEtch(vm, target, withMetadata);
         vm.expectRevert(LibExtrospectBytecode.UnexpectedMetadata.selector);
         this.checkNoSolidityCBORMetadataExternal(target);
     }


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/86

## What was wrong

`vm.etch` reads any account code prefixed `0xEF01` as an EIP-7702 delegation designator and rejects it unless it is exactly 23 bytes with a zero version byte at index 2. Four fuzz tests guarded their input with `vm.assume(!LibExtrospectBytecode.isEOFBytecode(code))`, which matches `0xEF00` only, so `0xEF01`-prefixed fuzz input reached `vm.etch` and failed the run.

Reproduced on `main` at `32f7325` with the seed from the issue comment:

```
$ nix develop -c forge test \
    --match-test 'testCheckCBORTrimmedBytecodeHashFuzz|testCheckCBORTrimmedBytecodeHashNoMetadataFuzz' \
    --fuzz-seed 0xea7bf00b4e56b2440289f45c67812ee0d44bd0f644d9a5f2a3aad5be41561240

[FAIL: vm.etch: failed to create bytecode: Eip7702 is not 23 bytes long; ... args=[0xef01e8ca4630bc62619fd019a890e4de496295ee3586eebdb070893a2228228150, ...]] testCheckCBORTrimmedBytecodeHashFuzz(bytes,bytes32) (runs: 976, ...)
[FAIL: ... same counterexample] testCheckCBORTrimmedBytecodeHashNoMetadataFuzz(bytes,bytes32) (runs: 240, ...)
Ran 1 test suite: 0 tests passed, 2 failed, 0 skipped (2 total tests)
```

The stickiness claim also reproduces: after that run, `--fuzz-seed 0x11` replays the persisted counterexample from `cache/fuzz/failures/` and fails again at `runs: 8`.

## The exact acceptance rule

Probed directly against `vm.etch` on this toolchain (foundry nightly from the `rainix` flake, `evm_version = "cancun"`):

| code | `vm.etch` |
| --- | --- |
| `0xEF00…` at any length (incl. 2, 5, 23) | accepted |
| `0xEF02…`, `0xEFFF…`, bare `0xEF`, empty | accepted |
| `0xEF01` + anything, length ≠ 23 | rejected: `Eip7702 is not 23 bytes long` |
| `0xEF01` + 21 bytes, version byte ≠ 0 | rejected: `Unsupported Eip7702 version` |
| `0xEF0100` + 20 address bytes (23 total) | accepted |

So the guard the tests need is not "no `0xEF` prefix" — that would also exclude the `0xEF00` cases the suite deliberately etches, and the valid delegation designator, which is a real on-chain account code shape. It is exactly the rule above.

## The change

Test-only. No `src/` file is touched, so **no verdict this library reaches about any contract changes**.

`test/lib/LibExtrospectTestEtch.sol` carries the property once:

```solidity
function etchAcceptsEIP7702(bytes memory code) internal pure returns (bool) {
    if (code.length >= 2 && code[0] == 0xEF && code[1] == 0x01) {
        return code.length == 23 && code[2] == 0x00;
    }
    return true;
}

function assumeEtch(Vm vm, address target, bytes memory code) internal {
    vm.assume(etchAcceptsEIP7702(code));
    vm.etch(target, code);
}
```

All four fuzz-derived etch sites route through `assumeEtch`:

- `LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol` — `testCheckNoMetadataPassesFuzz`, `testCheckNoMetadataRevertsFuzz`
- `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` — `testCheckCBORTrimmedBytecodeHashFuzz`, `testCheckCBORTrimmedBytecodeHashNoMetadataFuzz`

The eight `vm.etch` sites that etch fixed constants are unchanged — they are not fuzz-derived and cannot hit the rule.

Guarding the *etched payload* rather than the fuzz argument matters for the two tests that etch `code || metadata`: those payloads are always ≥ 51 bytes, so any `0xEF01`-prefixed `code` is correctly rejected there, while a bare 23-byte designator stays in the domain of the two tests that etch `code` directly.

`vm.assume(!isEOFBytecode(code))` is left at every call site. That guard expresses what the tests want from the library, not what `vm.etch` will take, and the two are now separate.

## Test layout

`test/lib/LibExtrospectTestEtch.t.sol` sits beside its subject, matching the `test/src/**` mirrors `src/**` rule applied within the test tree. It is the first `.t.sol` under `test/lib/`.

Every case asserts the predicate **and** the real `vm.etch` outcome for the same bytes, so the test cannot drift from foundry's behaviour without failing:

```solidity
function checkEtchAccepts(bytes memory code, bool expected) internal {
    assertEq(LibExtrospectTestEtch.etchAcceptsEIP7702(code), expected, "predicate");
    (bool ok,) = address(vm).call(abi.encodeWithSignature("etch(address,bytes)", TARGET, code));
    assertEq(ok, expected, "vm.etch");
}
```

`testAssumeEtchRejectsRun` asserts the reject path is `vm.assume` and not `vm.etch`, by checking the revert data is exactly `FOUNDRY::ASSUME`.

## Runs

Both runs exclude only the three Arbitrum-fork tests, which need `ARBITRUM_RPC_URL` (absent locally; present in CI). `ExtrospectConstantsTest` is kept in — it pins deployed bytecode of `src/`, and nothing in this PR touches `src/`.

```
$ nix develop -c forge test --no-match-test \
    'testCheckCBORTrimmedBytecodeHashSuccess|testCheckCBORTrimmedBytecodeHashFailure|testCheckCBORTrimmedBytecodeHashMetadataNotTrimmed'
```

| | seed `0x1` | seed `0xea7bf00b…` (the red one) |
| --- | --- | --- |
| `main` @ `32f7325` | 311 passed / 0 failed | 309 passed / **2 failed** |
| this branch | 325 passed / 0 failed | 325 passed / 0 failed |

Reproduction of the pre-fix red, full suite, same exclusions:

```
$ git checkout main && rm -rf cache/fuzz
$ nix develop -c forge test --no-match-test '…fork tests…' \
    --fuzz-seed 0xea7bf00b4e56b2440289f45c67812ee0d44bd0f644d9a5f2a3aad5be41561240
Encountered a total of 2 failing tests, 309 tests succeeded
```

## Adversarial mutation pass

Every mutant ran the full suite under the same filter, with `cache/fuzz` cleared first so no persisted counterexample could fake a kill:

```
$ nix develop -c forge test \
    --no-match-test 'testCheckCBORTrimmedBytecodeHashSuccess|testCheckCBORTrimmedBytecodeHashFailure|testCheckCBORTrimmedBytecodeHashMetadataNotTrimmed' \
    --no-match-contract 'ExtrospectConstantsTest' --fuzz-seed 0x1
```

**Proof the tests ran:** every row below reports `322 total tests`, and the unmutated baseline under the identical filter is `322 passed / 0 failed` at seed `0x1` and at the red seed. A filter that matched nothing, or a harness that failed to compile, would not produce 322.

`ExtrospectConstantsTest` is excluded because it pins deployed bytecode and would report KILLED for every mutant. It could not have faked a kill here anyway — every mutation is test-only, so `src/` bytecode is byte-identical throughout — but excluding it keeps the ledger honest.

| # | mutation | result | killed by (deterministic killers named first) |
| --- | --- | --- | --- |
| M01 | `code.length >= 2` → `code.length > 2` | KILLED, 3 failed | `testEtchRejectsEIP7702PrefixAlone`; 2 fuzz |
| M02 | `code[0] == 0xEF` → `code[0] == 0xEE` | KILLED, 10 failed | all 5 `testEtchRejectsEIP7702*`, `testAssumeEtchRejectsRun`; 4 fuzz |
| M03 | `code[1] == 0x01` → `code[1] == 0x00` | KILLED, 12 failed | all 5 `testEtchRejectsEIP7702*`, `testEtchAcceptsEOFPrefix`, `testAssumeEtchSetsEOFCode`, `testAssumeEtchRejectsRun`; 4 fuzz |
| M04 | `code.length == 23` → `code.length >= 23` | KILLED, 5 failed | `testEtchRejectsEIP7702PrefixTooLong`; 4 fuzz |
| M05 | `code.length == 23` → `code.length == 24` | KILLED, 4 failed | `testEtchAcceptsEIP7702Designator`, `testEtchRejectsEIP7702PrefixTooLong`; 2 fuzz |
| M06 | `code[2] == 0x00` → `code[2] != 0x00` | KILLED, 4 failed | `testEtchAcceptsEIP7702Designator`, `testEtchRejectsEIP7702BadVersion`; 2 fuzz |
| M07 | designator branch → `return true` | KILLED, 10 failed | all 5 `testEtchRejectsEIP7702*`, `testAssumeEtchRejectsRun`; 4 fuzz |
| M08 | trailing `return true` → `return false` | KILLED, 11 failed | all 7 accept-side tests; 4 fuzz (`vm.assume` rejected too many inputs) |
| M09 | delete `vm.assume(etchAcceptsEIP7702(code))` | KILLED, 5 failed | `testAssumeEtchRejectsRun`; 4 fuzz |
| M10 | delete `vm.etch(target, code)` | KILLED, 4 failed | `testAssumeEtchSetsCode`, `testAssumeEtchSetsEOFCode`; 2 fuzz |
| M11 | `vm.assume(p)` → `vm.assume(!p)` | KILLED, 7 failed | `testAssumeEtchRejectsRun`, `testAssumeEtchSetsCode`, `testAssumeEtchSetsEOFCode`; 4 fuzz |
| M12 | call sites reverted to bare `vm.etch` (red seed) | KILLED, 2 failed | `testCheckCBORTrimmedBytecodeHashFuzz`, `testCheckCBORTrimmedBytecodeHashNoMetadataFuzz` |
| M13 | `if (…0xEF01 prefix…)` → `if (false)` | KILLED, 10 failed | all 5 `testEtchRejectsEIP7702*`, `testAssumeEtchRejectsRun`; 4 fuzz |

**13 mutants, 13 killed, 0 survived.** M12 is the fix itself: reverting the call sites reproduces exactly the two failures the issue reports, and nothing else.

Only the fuzz-test kills depend on the seed. Every mutant except M12 also has at least one deterministic unit-test killer, so the ledger does not rest on fuzz luck. M12's two killers are pinned to the seed named in the issue.

## What this does not fix

`isEOFBytecode` matching only `0xEF00` is a live library question filed separately. This PR does not touch it; it only stops the test harness from depending on that predicate for something it was never about.

## QA
- Discriminating tests: `testEtchRejectsEIP7702PrefixAlone`, `testEtchRejectsEIP7702PrefixTooShort`, `testEtchRejectsEIP7702PrefixTooLong`, `testEtchRejectsEIP7702BadVersion`, `testEtchRejectsEIP7702Counterexample`, `testEtchAcceptsEIP7702Designator`, `testEtchAcceptsEOFPrefix`, `testEtchAcceptsOtherEFPrefixes`, `testEtchAcceptsBareEF`, `testEtchAcceptsEmpty`, `testEtchAcceptsLegacyBytecode`, `testAssumeEtchSetsCode`, `testAssumeEtchSetsEOFCode`, `testAssumeEtchRejectsRun` — all 14 are new and cannot exist on base, since `LibExtrospectTestEtch` does not exist there. The behaviour they lock is verified failing on base by the pre-existing tests: `main` @ `32f7325` at seed `0xea7bf00b…` gives `2 failing tests, 309 tests succeeded`; this branch at the same seed gives `325 passed / 0 failed`. Each new test also fails on this branch under the matching mutant, per the table above.
- Mutations applied: 13, all killed, 0 survived. `code.length >= 2` → `> 2` killed by `testEtchRejectsEIP7702PrefixAlone`; `code[0] == 0xEF` → `0xEE` killed by all 5 `testEtchRejectsEIP7702*`; `code[1] == 0x01` → `0x00` killed by `testEtchAcceptsEOFPrefix` and `testAssumeEtchSetsEOFCode`; `code.length == 23` → `>= 23` killed by `testEtchRejectsEIP7702PrefixTooLong`; `code.length == 23` → `== 24` killed by `testEtchAcceptsEIP7702Designator`; `code[2] == 0x00` → `!= 0x00` killed by `testEtchRejectsEIP7702BadVersion`; designator branch → `return true` killed by all 5 `testEtchRejectsEIP7702*`; trailing `return true` → `return false` killed by all 7 accept-side tests; `vm.assume(...)` deleted killed by `testAssumeEtchRejectsRun`; `vm.etch(...)` deleted killed by `testAssumeEtchSetsCode`; `vm.assume(p)` → `vm.assume(!p)` killed by `testAssumeEtchRejectsRun`; `if (…0xEF01…)` → `if (false)` killed by all 5 `testEtchRejectsEIP7702*`; call sites reverted to bare `vm.etch` killed by `testCheckCBORTrimmedBytecodeHashFuzz` and `testCheckCBORTrimmedBytecodeHashNoMetadataFuzz` at the issue's seed.
- Oracle: `vm.etch` itself, not the implementation. `checkEtchAccepts` asserts the predicate's answer and separately calls the `etch` cheatcode through `address(vm).call` for the same bytes, asserting the two agree — the expected values come from foundry's own accept/reject behaviour, so the predicate cannot drift from it silently. `testAssumeEtchRejectsRun` uses the literal `FOUNDRY::ASSUME` revert data as the oracle for which rejection path fired.
- Category check: the issue names `testCheckNoMetadataPassesFuzz` and `testCheckNoMetadataRevertsFuzz`; its comment widens the ask to the property "every fuzz test in the repo that etches fuzz-derived bytes and guards only on `isEOFBytecode`". Covered as the property — all four fuzz-derived `vm.etch` sites in the repo route through one guard, and the remaining eight `vm.etch` sites etch fixed constants that cannot trip the rule. Also covered: the sticky `cache/fuzz/failures` replay, which no longer has a counterexample to persist. Not covered, deliberately: `isEOFBytecode`'s own narrowness, which is a separate issue and a library-verdict question.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for bytecode installation under EIP-7702 rules, including valid, invalid, legacy, EOF-prefixed, empty, and malformed bytecode.
  * Improved fuzz testing by safely handling bytecode rejected by the installation mechanism.
  * Continued validating metadata trimming, hash mismatches, and related error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->