### PR TITLE
Add a mutation profile that drops the deploy-constant bytecode pins

### DIFF
--- a/.claude/rules/mutation-profile.md
+++ b/.claude/rules/mutation-profile.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "src/**"
+  - "test/**"
+  - "foundry.toml"
+---
+
+# Mutation and coverage campaigns run under `FOUNDRY_PROFILE=mutation`
+
+```bash
+nix develop -c bash -c 'FOUNDRY_PROFILE=mutation forge test'
+```
+
+`ExtrospectConstantsTest` (`test/src/concrete/Extrospect.constants.t.sol`) pins
+`type(Extrospect).creationCode` and `type(Extrospect).runtimeCode` against the
+`EXTROSPECT_*_V1` constants. Those compiler outputs change for any edit to any
+source file reachable from `Extrospect`, so `testExtrospectCreationBytecode` and
+`testExtrospectRuntimeCodehash` both fail under every source mutation, whether or
+not the mutated behaviour is observable. A campaign run on the default profile
+scores every mutant `KILLED` and measures nothing.
+
+`[profile.mutation]` in `foundry.toml` sets
+`no_match_contract = "ExtrospectConstantsTest"` and inherits everything else from
+`default`. The default profile keeps the pins, so CI and releases still catch
+constant drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,15 +33,9 @@ nix develop -c forge test
 nix develop -c forge test --match-contract LibExtrospectBytecodeIsEOFBytecodeTest
 nix develop -c forge test --match-test testFoo
 
-# Mutation / coverage campaigns (drops the deploy-constant pins)
+# Mutation / coverage campaigns — see .claude/rules/mutation-profile.md
 nix develop -c bash -c 'FOUNDRY_PROFILE=mutation forge test'
 ```
-
-### The `mutation` profile
-
-`ExtrospectConstantsTest` (`test/src/concrete/Extrospect.constants.t.sol`) pins `type(Extrospect).creationCode` and `type(Extrospect).runtimeCode` against the `EXTROSPECT_*_V1` constants. Those compiler outputs change for any edit to any source file reachable from `Extrospect`, so both pins fail under every source mutation, whether or not the mutated behaviour is observable. Under the default profile a mutation campaign therefore scores every mutant `KILLED` and measures nothing.
-
-`FOUNDRY_PROFILE=mutation` runs the same suite with `no_match_contract = "ExtrospectConstantsTest"`. Every mutation or coverage campaign on this repo runs under it. The default profile keeps the pins, so CI and releases still catch constant drift.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,16 @@ nix develop -c rainix-sol-legal
 nix develop -c forge test
 nix develop -c forge test --match-contract LibExtrospectBytecodeIsEOFBytecodeTest
 nix develop -c forge test --match-test testFoo
+
+# Mutation / coverage campaigns (drops the deploy-constant pins)
+nix develop -c bash -c 'FOUNDRY_PROFILE=mutation forge test'
 ```
+
+### The `mutation` profile
+
+`ExtrospectConstantsTest` (`test/src/concrete/Extrospect.constants.t.sol`) pins `type(Extrospect).creationCode` and `type(Extrospect).runtimeCode` against the `EXTROSPECT_*_V1` constants. Those compiler outputs change for any edit to any source file reachable from `Extrospect`, so both pins fail under every source mutation, whether or not the mutated behaviour is observable. Under the default profile a mutation campaign therefore scores every mutant `KILLED` and measures nothing.
+
+`FOUNDRY_PROFILE=mutation` runs the same suite with `no_match_contract = "ExtrospectConstantsTest"`. Every mutation or coverage campaign on this repo runs under it. The default profile keeps the pins, so CI and releases still catch constant drift.
 
 ## Architecture
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,6 +2,7 @@ version = 1
 
 [[annotations]]
 path = [
+  ".claude/**/",
   ".gas-snapshot",
   ".github/workflows/**/",
   ".vscode/**/",

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,16 @@ libs = ["dependencies"]
 [fuzz]
 runs = 2048
 
+# Behaviour-only view of the test suite, for mutation and coverage campaigns.
+# `ExtrospectConstantsTest` pins `type(Extrospect).creationCode` and
+# `type(Extrospect).runtimeCode`, which change for any edit to any source file
+# reachable from `Extrospect`. Those pins therefore fail under every source
+# mutation, observable or not, so a campaign that includes them scores every
+# mutant as killed. This profile drops them and inherits everything else from
+# `default`.
+[profile.mutation]
+no_match_contract = "ExtrospectConstantsTest"
+
 [dependencies]
 forge-std = "1.16.1"
 "rain-solmem" = "0.1.3"

--- a/test/src/concrete/Extrospect.constants.t.sol
+++ b/test/src/concrete/Extrospect.constants.t.sol
@@ -16,6 +16,9 @@ import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 /// deterministic Zoltu address, runtime codehash — so the deploy script
 /// and downstream consumers can rely on them as source of truth. If any
 /// fails the constant must be updated to match the current source.
+/// @dev These pin compiler output, not behaviour: they fail for any edit to
+/// any source file reachable from `Extrospect`. The `mutation` foundry
+/// profile excludes this contract by name.
 contract ExtrospectConstantsTest is Test {
     /// `EXTROSPECT_CREATION_BYTECODE_V1` matches the current compiler
     /// output. Compiler/optimizer settings affect creation bytecode, so


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/84

## The claim, verified on current main

`ExtrospectConstantsTest.testExtrospectCreationBytecode` and
`testExtrospectRuntimeCodehash` assert compiler output. Compiler output changes
for any edit to any source file reachable from `Extrospect`, so both fail under
every source mutation regardless of whether the mutated behaviour is
observable. A mutation matrix that counts "any test failed" as a kill therefore
scores every mutant `KILLED` at whole-suite scope.

Reproduced at `32f7325` over 12 mutants. Every one of them, without exception,
added exactly those two failures under the default profile — including two
mutants that are **provably behaviour-preserving** and one that is a **real
coverage gap**. The third pin, `testExtrospectZoltuAddress`, derives from the
pinned constant rather than from compiler output, so it never fires; the false
kill is worth exactly 2 tests per mutant.

## What changed

- `foundry.toml` — new `[profile.mutation]` with
  `no_match_contract = "ExtrospectConstantsTest"`. Inherits everything else
  from `default`, including `[fuzz] runs = 2048` (confirmed in the run output).
- `.claude/rules/mutation-profile.md` — the record the issue asks for: what the
  pins assert, why that makes them fail under every source mutation, and the
  profile campaigns run under. `paths:`-scoped to `src/**`, `test/**` and
  `foundry.toml`.
- `CLAUDE.md` — two lines in the `Build & Test` block: the command, and a
  pointer to the rule.
- `REUSE.toml` — `.claude/**/` added to the annotated paths so the new file is
  licensed (`reuse lint` clean).
- `test/src/concrete/Extrospect.constants.t.sol` — a `@dev` line on the contract
  saying these pin compiler output rather than behaviour, and naming the profile
  that excludes them.

No source file changes. No verdict this library reaches changes. The pins stay
in the default profile, so CI and releases still catch constant drift.

The record is a scoped rule rather than a `CLAUDE.md` section because this repo
is under rainix's 4096-byte agent-context cap, and the first push of this branch
failed `rainix-sol / static` on exactly that: `CLAUDE.md` reached 4282 bytes with
the section inline, 186 over. `paths:` frontmatter takes a rule out of the launch
context entirely — `agent-context-cap` charges only unscoped rules — which is
what the check's own message prescribes. `CLAUDE.md` is now 3528 bytes against a
3392-byte base.

The issue also asks for the same record in the audit skill. That skill lives
outside this repo and is not touched here.

## Baselines

`ARBITRUM_RPC_URL` is absent in this environment, so the fork-only file
`test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` is
excluded from every run below (issue #85 covers what that exclusion costs — it
drops 7 tests to run 4 non-fork checks that would otherwise be measured).

```
nix develop -c forge test --no-match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'
  default   307 tests passed, 0 failed, 0 skipped (307 total tests)
  mutation  304 tests passed, 0 failed, 0 skipped (304 total tests)
```

The whole suite with nothing excluded is 311 passed / 3 failed (314 total), the
3 being the fork tests that need `ARBITRUM_RPC_URL`.

## Mutation pass

12 mutants across all five source files, each run twice over the same tree —
once on `default`, once on `mutation`. `KILLED by` lists the distinct failing
tests. Full per-run logs are in the campaign artifacts; every run reports its
own total-test line, so a run that failed to compile or matched zero tests is
distinguishable from a survivor.

`testCheckNoMetadataPassesFuzz` / `testCheckNoMetadataRevertsFuzz` are counted
separately as `flaky` — see the last section; they fire on mutants in code they
do not touch, so counting them as killers would repeat the same measurement
error in a different place.

| ID | Mutation | `default` | `mutation` |
| --- | --- | --- | --- |
| M1 | `LibExtrospectERC1167Proxy` implementation mask `type(uint160).max` → `type(uint256).max` | KILLED — 2 pins + `testIsERC1167ProxyImplementationAddressIsCleanWord` | KILLED — `testIsERC1167ProxyImplementationAddressIsCleanWord` |
| M2 | `ERC1167_PREFIX_LENGTH` `10` → `9` | KILLED — 2 pins + 7 real | KILLED — 7 real |
| M3 | `isERC1167Proxy` length gate `!=` → `<` | KILLED — 2 pins + 3 real | KILLED — 3 real |
| M4 | beacon dirty-bits gate `type(uint160).max` → `type(uint168).max` | KILLED — **2 pins, nothing else** | **SURVIVED** — genuine gap |
| M5 | beacon `returnData.length != 32` check dropped | KILLED — 2 pins + 2 flaky + 2 real | KILLED — 2 real |
| M6 | `isBeaconImplementationBytecode` ignores the staticcall `success` flag | KILLED — 2 pins + 2 flaky + 7 real | KILLED — 7 real |
| M7 | EOF magic `0xEF00` → `0xEF01` | KILLED — 2 pins + 12 real | KILLED — 12 real |
| M8 | metamorphic revert gate `riskyOpcodes != 0` → `> 1` (**equivalent**) | KILLED — **2 pins, nothing else** | **SURVIVED** — correct |
| M9 | `CREATE2` dropped from `METAMORPHIC_OPS` | KILLED — 2 pins + 2 flaky + 5 real | KILLED — 5 real |
| M10 | reachable scan PUSH range `lt(push, 0x20)` → `0x1F` | KILLED — 2 pins + 2 flaky + 7 real | KILLED — 7 real |
| M11 | halted-resume test `eq(op, JUMPDEST)` → `gt` | KILLED — 2 pins + 2 flaky + 31 real | KILLED — 31 real |
| E1 | swap the two `isERC1167Proxy` prefix/suffix checks (**equivalent**) | KILLED — **2 pins, nothing else** | **SURVIVED** — correct |

`default`: 12/12 killed — 100%, and worth nothing, since two of the twelve
cannot change behaviour at all. `mutation`: 9 killed, 3 survived, two of those
three provably equivalent. True score 9/10 non-equivalent mutants, with M4 the
one real gap.

M4, M8 and E1 re-run in isolation with the flaky pair excluded, so "pins,
nothing else" is measured rather than inferred:

```
--no-match-test 'testCheckNoMetadata(Passes|Reverts)Fuzz'
  M4 default   303 passed, 2 failed :: testExtrospectCreationBytecode, testExtrospectRuntimeCodehash
  M4 mutation  302 passed, 0 failed :: none
  M8 default   303 passed, 2 failed :: testExtrospectCreationBytecode, testExtrospectRuntimeCodehash
  M8 mutation  302 passed, 0 failed :: none
  E1 default   303 passed, 2 failed :: testExtrospectCreationBytecode, testExtrospectRuntimeCodehash
  E1 mutation  302 passed, 0 failed :: none
```

### The three mutants that carry the finding

**E1** swaps the two prefix/suffix checks in `isERC1167Proxy`. Both are
`result := and(result, eq(keccak256(...), ...))` over disjoint memory regions
with no side effects, and `and` is commutative, so the swap is
behaviour-preserving by construction — no behavioural test can distinguish it,
and none should. The default profile calls it `KILLED` anyway, on the pins
alone.

**M8** widens the metamorphic revert gate from `riskyOpcodes != 0` to
`riskyOpcodes > 1`. `riskyOpcodes` is masked with `METAMORPHIC_OPS`, whose
lowest member is bit `0xF0` (CREATE), so `riskyOpcodes == 1` is unreachable and
the two gates are equivalent. Same result: `KILLED` under `default` on the pins
alone, `SURVIVED` under `mutation`, correctly.

**M4** is not equivalent. Widening the beacon dirty-bits gate from
`raw > type(uint160).max` to `type(uint168).max` accepts 32-byte returndata with
bits 160-167 set and silently truncates it to an address, where main returns
`(false, address(0))`. Nothing in the suite covers that: `BogusBeacon` returns
`type(uint256).max` (every upper bit set, rejected either way) and
`testMatchesAtMaxAddressBoundary` pins `2**160 - 1` on the accept side, with
nothing at `2**160` on the reject side. That is a genuine coverage gap the pins
were hiding, and it is exactly the failure mode issue #84 describes. Filed as
https://github.com/rainlanguage/rain.extrospection/issues/124
rather than folded in here, since it belongs to the beacon test
files that several open PRs are already editing.

## Incidental: #86 confirmed live

`testCheckNoMetadataPassesFuzz` and `testCheckNoMetadataRevertsFuzz` failed on
8 of 13 runs, including on mutants in code they do not touch (a
`METAMORPHIC_OPS` bit, the beacon staticcall wrapper) and on the
behaviour-preserving E1 — the fuzz corpus reshuffles with the bytecode. That is
issue #86 and it is not addressed here; both tests are excluded from the
isolation runs above so they cannot be mistaken for killers, and the isolation
baseline is green with them excluded:

```
--no-match-test 'testCheckNoMetadata(Passes|Reverts)Fuzz'
  default   305 tests passed, 0 failed, 0 skipped (305 total tests)
  mutation  302 tests passed, 0 failed, 0 skipped (302 total tests)
```

It also hits an unmutated tree — the branch head with no source edit goes red on
`--fuzz-seed 0x4fe370c0a55fb191ce8b6737f69380a43638df399f313449a2956ced92a2a512`,
`vm.etch: Eip7702 is not 23 bytes long`, counterexample
`0xef01acdc196069791c73902e`, at `runs: 0`. Posted to #86 as a deterministic
repro.

## QA
- Discriminating tests: n/a — this diff adds no test. It adds a foundry profile, a `paths:`-scoped `.claude/rules` file, two `CLAUDE.md` lines, a `REUSE.toml` path and one `@dev` line; every existing test keeps the same result under the default profile (307 passed / 0 failed with the fork file excluded, unchanged from main). The profile's own behaviour is measured rather than asserted: `FOUNDRY_PROFILE=mutation` selects 304 tests across 25 suites vs 307 across 27, the difference being exactly `ExtrospectConstantsTest`'s 3 tests.
- Mutations applied: 12 mutants across all five `src/` files, each run on both profiles — full table above. `src/lib/LibExtrospectERC1967BeaconProxy.sol` `_tryGetAddress`: `raw > type(uint160).max` → `type(uint168).max` (M4) → killed by nothing but the two pins. `src/lib/LibExtrospectMetamorphic.sol` `checkNotMetamorphic`: `riskyOpcodes != 0` → `riskyOpcodes > 1` (M8) → killed by nothing but the two pins. `src/lib/LibExtrospectERC1167Proxy.sol` `isERC1167Proxy`: prefix and suffix check blocks swapped (E1) → killed by nothing but the two pins. The other nine (M1, M2, M3, M5, M6, M7, M9, M10, M11) are killed by named behavioural tests under both profiles.
- Oracle: the mutants, not the source. E1 and M8 are behaviour-preserving by an argument independent of the implementation — `and` is commutative over side-effect-free operands, and `METAMORPHIC_OPS`' lowest member is bit `0xF0` so `riskyOpcodes == 1` is unreachable — so an honest suite MUST report them SURVIVED. The default profile reporting them KILLED is the defect, demonstrated rather than asserted. Harness honesty: each run's totals line is parsed from its own log, so a compile failure or a zero-match filter reads `HARNESS-ERROR` rather than passing as a survivor, and each mutated file is diffed against the pristine copy before its runs so a `sed` that matched nothing reads `NOT-APPLIED` (two did on the first pass and were re-run).
- Category check: the issue asks (a) record that mutation and coverage campaigns must exclude `ExtrospectConstantsTest`, and (b) consider a separate profile or tag so the pins are not silently counted as behavioural coverage. Covered (a) in `.claude/rules/mutation-profile.md`, pointed at from `CLAUDE.md`'s command list, plus a `@dev` line on the contract itself; covered (b) as `[profile.mutation]`, which makes the exclusion mechanical rather than a prose instruction. The issue's third target, the same record in the audit skill, lives outside this repo and is not touched. Deliberately not covered here: the M4 coverage gap that the corrected measurement exposed, filed as https://github.com/rainlanguage/rain.extrospection/issues/124 because it belongs to beacon test files that several open PRs are already editing.
