### PR TITLE
docs: reconcile each audit report's stated scope against its reviewed tree

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -1,0 +1,87 @@
+# Audits
+
+Reports live in `audit/protofire/`. Each report carries a **Reviews** table
+naming the commits it reviewed, and a **Scope > Contracts** table naming the
+Solidity files it covers.
+
+Every report's scope table is the union of files across the commits in its own
+Reviews table, not the scope of its latest round alone. A report therefore lists
+paths that do not exist at the commit it most recently reviewed.
+
+This file records, per report, how the stated scope compares to `src/` at the
+latest commit that report reviewed.
+
+## `rain.extrospection.f2c4f5a.feb-2026.pdf`
+
+Reviews `60f35a0` (30/01/26), `4c0aed6` (05/02/26), `f2c4f5a` (10/02/26).
+
+Scope lists 8 files. `src/` at `f2c4f5a` holds the same 8 files.
+
+## `rain.extrospection.ab33ddb-r2.1.feb-2026.pdf`
+
+Reviews `60f35a0` (30/01/26), `4c0aed6` (05/02/26), `ab33ddb` (10/02/26). The
+extracted text is identical to the `f2c4f5a` report apart from the commit hash
+in the third Reviews row.
+
+Scope lists 8 files. `src/` at `ab33ddb` holds 7. Scope names
+`src/concrete/Extrospection.sol`, which does not exist at `ab33ddb`. Every file
+in the tree is scoped.
+
+## `rain.extrospection.v0.1.1-r3.0.may-2026.pdf`
+
+Reviews `60f35a0` (30/01/26), `4c0aed6` (05/02/26), `ab33ddb` (10/02/26),
+`f9a4674` (24/02/26), `2b0d2cf` (26/05/26, tag `v0.1.1`).
+
+Scope lists 13 files. `src/` at `2b0d2cf` holds 9.
+
+Scoped, absent from `src/` at `2b0d2cf`:
+
+- `src/concrete/Extrospection.sol`
+- `src/interface/deprecated/IExtrospectBytecodeV1.sol`
+- `src/interface/IExtrospectBytecodeV2.sol`
+- `src/interface/IExtrospectERC1167ProxyV1.sol`
+- `src/interface/IExtrospectInterpreterV1.sol`
+
+Present in `src/` at `2b0d2cf`, not scoped:
+
+- `src/lib/LibExtrospectMetamorphic.sol`
+
+The 13 scoped paths are the union of the files present across the five reviewed
+commits, less `src/lib/LibExtrospectMetamorphic.sol`.
+
+Two findings, `H02` and `L03`, carry
+`Path: src/interface/IExtrospectInterpreterV1.sol`, a path absent at `2b0d2cf`.
+Both are marked found at `60f35a0`/`4c0aed6` and fixed before `2b0d2cf`.
+
+## Coverage of `src/lib/LibExtrospectMetamorphic.sol`
+
+`src/lib/LibExtrospectMetamorphic.sol` exists at `f9a4674` and `2b0d2cf`, the
+fourth and fifth reviewed commits. No report in `audit/protofire/` names it in
+its scope table. No finding in any report names it: the only finding path that
+reaches it is `M02`, whose `Path` is the wildcard `src/*`, found at `60f35a0`
+where the file did not yet exist. The string `metamorphic` does not appear in
+the extracted text of any of the three reports.
+
+The library supplies `IExtrospectV1.checkNotMetamorphic` and
+`IExtrospectV1.scanMetamorphicRisk` through `src/concrete/Extrospect.sol`.
+
+## Reproducing
+
+Extract a report's scope table (`pdftotext` is in nixpkgs `poppler-utils`):
+
+```
+pdftotext -layout audit/protofire/<report>.pdf - \
+  | sed -n '/^Scope$/,/^Technical analysis/p'
+```
+
+List the source tree at a reviewed commit:
+
+```
+git ls-tree -r --name-only <commit> -- src/
+```
+
+Compare the current tree against the latest audited commit:
+
+```
+git diff --stat 2b0d2cf HEAD -- src/
+```


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/90

## Reproduced

Every claim in the issue reproduces against current `main` (`32f7325`). `src/` at
`32f7325` is byte-identical to `src/` at `2b0d2cf`, the commit the r3.0 report names
as its latest review, so the report's scope applies to the tree as it stands.

Reconciling each report's `Scope > Contracts` table against `git ls-tree` at the
latest commit that report reviewed:

| report | latest reviewed commit | scope paths | files in `src/` | scoped but absent | in tree but unscoped |
| --- | --- | --- | --- | --- | --- |
| `rain.extrospection.f2c4f5a.feb-2026.pdf` | `f2c4f5a` | 8 | 8 | 0 | 0 |
| `rain.extrospection.ab33ddb-r2.1.feb-2026.pdf` | `ab33ddb` | 8 | 7 | 1 | 0 |
| `rain.extrospection.v0.1.1-r3.0.may-2026.pdf` | `2b0d2cf` | 13 | 9 | 5 | **1** |

The one unscoped file is `src/lib/LibExtrospectMetamorphic.sol`.

Two things the issue asked to establish, now settled from the git history:

1. **The scope tables are cumulative, not per-round.** The r3.0 table's 13 paths are
   exactly the union of the files present across its five reviewed commits, less
   `src/lib/LibExtrospectMetamorphic.sol`. The same pattern holds one round earlier:
   the r2.1 table lists `src/concrete/Extrospection.sol`, which exists at `60f35a0`
   and `4c0aed6` but not at `ab33ddb`. So the five "phantom" paths are carry-over,
   not evidence of a review of files that never existed.

2. **There is no textual support for "the reviewers read it and the table is stale".**
   The string `metamorphic` does not appear anywhere in the extracted text of any of
   the three reports. No finding names the file. The only finding whose `Path` could
   reach it is `M02`, whose `Path` is the wildcard `src/*`, and `M02` is marked found
   at `60f35a0` — before the file existed.

   Under the cumulative reading, `LibExtrospectMetamorphic.sol` is the single file
   that was in a reviewed tree (at `f9a4674` and `2b0d2cf`) and appears in no table.

## What this changes

`audit/README.md`, new file, 87 lines of markdown. Nothing under `src/`.

It records per report: the reviewed commits, the size of the stated scope, which
scoped paths are absent from the tree, which tree files are unscoped, and the
commands to re-derive all of it. It states plainly that
`src/lib/LibExtrospectMetamorphic.sol` — which supplies
`IExtrospectV1.checkNotMetamorphic` and `IExtrospectV1.scanMetamorphicRisk` through
`src/concrete/Extrospect.sol` — is in no report's scope.

## What this does not change

**No verdict.** Zero Solidity lines change. `checkNotMetamorphic`,
`scanMetamorphicRisk`, and every other entry point accept and reject exactly what
they did before.

**The coverage gap itself.** A doc records the state; it does not audit the file.
Whether to ask Protofire for a scope amendment naming
`src/lib/LibExtrospectMetamorphic.sol`, or to commission a round that covers it, is
outside what a PR here can do. Flagging it for a decision rather than deciding it.

## Baseline

Both exclusions applied, per the harness facts established for this repo:

- `--no-match-contract ExtrospectConstantsTest` — pins deployed bytecode, so it fails
  under every source mutation and reports KILLED for every mutant, measuring nothing.
- `--no-match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'`
  — needs `ARBITRUM_RPC_URL`, absent here. This drops 7 tests; 4 of them pass without
  the RPC and are lost too, the other 3 are the failures issue #85 is about.

```
$ nix develop -c forge test --no-match-contract ExtrospectConstantsTest \
    --no-match-path 'test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol'
Ran 25 test suites in 459.10ms (5.19s CPU time): 304 tests passed, 0 failed, 0 skipped (304 total tests)
```

Unfiltered, for the record: `Ran 27 test suites ... 311 tests passed, 3 failed, 0
skipped (314 total tests)` — the 3 are the `ARBITRUM_RPC_URL` fork tests and nothing
else.

## Mutation pass

The diff carries no Solidity, so there is no mutant this PR could introduce. What is
worth knowing here instead is how well the repo's own tests hold the file the audit
does not cover, since that is the whole subject of the issue. Six mutants against
`src/lib/LibExtrospectMetamorphic.sol`, each run over the whole filtered suite:

| # | mutation | result | suite |
| --- | --- | --- | --- |
| M1 | `scan… & METAMORPHIC_OPS` -> `scan… \| METAMORPHIC_OPS` | KILLED | 299 passed, 5 failed / 304 |
| M2 | drop the `& METAMORPHIC_OPS` mask entirely | KILLED | 301 passed, 3 failed / 304 |
| M3 | `scanEVMOpcodesReachableInBytecode` -> `scanEVMOpcodesPresentInBytecode` | KILLED | 303 passed, 1 failed / 304 |
| M4 | `if (riskyOpcodes != 0)` -> `if (riskyOpcodes == 0)` | KILLED | 295 passed, 9 failed / 304 |
| M5 | `if (riskyOpcodes != 0)` -> `if (false)` (never revert) | KILLED | 297 passed, 7 failed / 304 |
| M6 | `revert Metamorphic(riskyOpcodes)` -> `revert Metamorphic(0)` | KILLED | 297 passed, 7 failed / 304 |

6/6 killed, 0 survived.

Proof the tests ran rather than the harness lying: every row above reports a real
`Ran 25 test suites … (304 total tests)` line with the total unchanged from baseline,
so no mutant silently failed to compile or filtered to zero matches. First killer per
mutant:

- M1 `testScanMetamorphicRiskClean` — `724778…491 != 0`
- M2 `testScanMetamorphicRiskClean` — `144881…395 != 0`
- M3 `testScanMetamorphicRiskReference(bytes)` — counterexample `0xfe4599f4c7883527657cba16853b0dca66553b58093723`
- M4 `testCheckNotMetamorphicClean` — `Metamorphic(0)`
- M5 `testCheckNotMetamorphicFuzz(bytes)` — next call did not revert as expected
- M6 `testCheckNotMetamorphicFuzz(bytes)` — `Metamorphic(0) != Metamorphic(565391…832)`

`src/lib/LibExtrospectMetamorphic.sol` is restored to `HEAD` and `git status` is clean
over `src/`.

## QA

- Discriminating tests: n/a - the diff is one new markdown file, `audit/README.md`, and zero Solidity lines. There is no behaviour to discriminate, and the standing ruling forbids tests that read or assert prose, so no test asserts this doc's contents.
- Mutations applied: n/a for the diff (no code changed). Run instead against the file the issue is about, `src/lib/LibExtrospectMetamorphic.sol`, 6/6 killed: `scan… & METAMORPHIC_OPS` -> `|` -> `testScanMetamorphicRiskClean`; drop the `& METAMORPHIC_OPS` mask -> `testScanMetamorphicRiskClean`; `scanEVMOpcodesReachableInBytecode` -> `scanEVMOpcodesPresentInBytecode` -> `testScanMetamorphicRiskReference(bytes)`; `if (riskyOpcodes != 0)` -> `== 0` -> `testCheckNotMetamorphicClean`; `if (riskyOpcodes != 0)` -> `if (false)` -> `testCheckNotMetamorphicFuzz(bytes)`; `revert Metamorphic(riskyOpcodes)` -> `revert Metamorphic(0)` -> `testCheckNotMetamorphicFuzz(bytes)`. Every run reports `Ran 25 test suites … (304 total tests)`, unchanged from the 304-passed baseline, so none silently failed to compile or filtered to zero matches.
- Oracle: the audit PDFs and git, both independent of `src/`. Scope tables extracted with `pdftotext -layout` (nixpkgs `poppler-utils`); trees from `git ls-tree -r --name-only <commit> -- src/` at the commits the reports' own Reviews tables name. Every count in the doc is re-derivable from those two commands and nothing in the doc is asserted from reading the Solidity.
- Category check: issue asks (A) the tree-vs-scope divergence in both directions, (B) whether the reviewers read `LibExtrospectMetamorphic.sol` with a merely stale table, (C) whether the five phantom paths are carry-over from earlier rounds. Covered A (reconciliation table, all three reports not just the one filed), B (no report's text contains `metamorphic`; no finding names the file; the only wildcard-path finding `M02` predates the file), C (each report's scope is the union across its own reviewed commits — established for r2.1 as well as r3.0). Not covered, and deliberately not: getting the report amended. That is an action against Protofire, not a change to this repo, and it is called out above for a decision rather than decided here.
