### PR TITLE
Document IExtrospectV1 with full NatSpec

### DIFF
--- a/src/interface/IExtrospectV1.sol
+++ b/src/interface/IExtrospectV1.sol
@@ -3,44 +3,141 @@
 pragma solidity ^0.8.25;
 
 /// @title IExtrospectV1
-/// @notice External interface for the concrete `Extrospect` contract.
-/// Function order matches the filesystem ordering of the per-function
-/// test files under `test/src/concrete/Extrospect.<fn>.t.sol`.
+/// @notice External interface for the concrete `Extrospect` contract. Every
+/// function forwards to the library function it names.
+/// @dev The custom errors named below are declared by the libraries, not by
+/// this interface. `EOFBytecodeNotSupported`, `MetadataNotTrimmed`,
+/// `BytecodeHashMismatch` and `UnexpectedMetadata` come from
+/// `LibExtrospectBytecode`; `Metamorphic` comes from
+/// `LibExtrospectMetamorphic`.
 interface IExtrospectV1 {
-    /// @notice See `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash`.
+    /// @notice Reads `account`'s runtime bytecode, trims trailing Solidity CBOR
+    /// metadata from it, and reverts unless what remains hashes to `expected`.
+    /// Reverts `MetadataNotTrimmed` when the bytecode does not end in the exact
+    /// metadata structure the trimmer recognises, so nothing was trimmed.
+    /// Reverts `BytecodeHashMismatch(expected, actual)` when the trimmed
+    /// bytecode hashes to something other than `expected`. Reverts
+    /// `EOFBytecodeNotSupported` when `account`'s bytecode is EOF. Returns
+    /// nothing when the hash matches.
+    /// @dev See `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash`.
+    /// @param account The account whose runtime bytecode is read and checked.
+    /// @param expected `keccak256` of the bytecode AFTER its last 53 bytes are
+    /// removed, not of the full runtime bytecode.
     function checkCBORTrimmedBytecodeHash(address account, bytes32 expected) external view;
 
-    /// @notice See `LibExtrospectBytecode.checkNoSolidityCBORMetadata`.
+    /// @notice Reads `account`'s runtime bytecode and reverts
+    /// `UnexpectedMetadata` when its last 53 bytes are the exact Solidity CBOR
+    /// metadata structure `tryTrimSolidityCBORMetadata` recognises. Reverts
+    /// `EOFBytecodeNotSupported` when `account`'s bytecode is EOF. Returns
+    /// nothing when no such metadata is detected, including an account with no
+    /// code, and metadata in any other shape.
+    /// @dev See `LibExtrospectBytecode.checkNoSolidityCBORMetadata`.
+    /// @param account The account whose runtime bytecode is read and checked.
     function checkNoSolidityCBORMetadata(address account) external view;
 
-    /// @notice See `LibExtrospectBytecode.checkNotEOFBytecode`.
+    /// @notice Reverts `EOFBytecodeNotSupported` when `bytecode` begins with
+    /// the EOF magic `0xEF00`. Returns nothing otherwise.
+    /// @dev See `LibExtrospectBytecode.checkNotEOFBytecode`.
+    /// @param bytecode The bytecode to check.
     function checkNotEOFBytecode(bytes memory bytecode) external pure;
 
-    /// @notice See `LibExtrospectMetamorphic.checkNotMetamorphic`.
+    /// @notice Reverts `Metamorphic(riskyOpcodes)` when any metamorphic risk
+    /// opcode is reachable in `bytecode`, carrying the same bitmap
+    /// `scanMetamorphicRisk` returns. Reverts `EOFBytecodeNotSupported` when
+    /// `bytecode` is EOF. Returns nothing when that bitmap is zero.
+    /// @dev See `LibExtrospectMetamorphic.checkNotMetamorphic`.
+    /// @param bytecode The bytecode to check.
     function checkNotMetamorphic(bytes memory bytecode) external pure;
 
-    /// @notice See `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`.
+    /// @notice Static-calls `implementation()` on `beacon` and hashes the
+    /// runtime bytecode of the address it returns.
+    /// @dev See `LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode`.
+    /// @param beacon The address to static-call `implementation()` on.
+    /// @param expectedRuntimeHash `keccak256` of the implementation's runtime
+    /// bytecode exactly as deployed, with no metadata trimming. For an
+    /// implementation with no code this is `keccak256` of empty bytes.
+    /// @return True when the static call succeeds, returns exactly 32 bytes
+    /// whose top 12 bytes are zero, and the address in those bytes has runtime
+    /// bytecode hashing to `expectedRuntimeHash`. False when the static call
+    /// reverts, returns other than 32 bytes, or returns 32 bytes with any of
+    /// the top 12 non-zero.
     function isBeaconImplementationBytecode(address beacon, bytes32 expectedRuntimeHash) external view returns (bool);
 
-    /// @notice See `LibExtrospectERC1967BeaconProxy.isBeaconOwner`.
+    /// @notice Static-calls `owner()` on `beacon` and compares the address it
+    /// returns against `expectedOwner`.
+    /// @dev See `LibExtrospectERC1967BeaconProxy.isBeaconOwner`.
+    /// @param beacon The address to static-call `owner()` on.
+    /// @param expectedOwner The address the call must return.
+    /// @return True when the static call succeeds, returns exactly 32 bytes
+    /// whose top 12 bytes are zero, and the address in those bytes equals
+    /// `expectedOwner`. False when the static call reverts, returns other than
+    /// 32 bytes, or returns 32 bytes with any of the top 12 non-zero.
     function isBeaconOwner(address beacon, address expectedOwner) external view returns (bool);
 
-    /// @notice See `LibExtrospectBytecode.isEOFBytecode`.
+    /// @notice Whether `bytecode` begins with the EOF magic `0xEF00`. Never
+    /// reverts. Bytecode shorter than 2 bytes is not EOF.
+    /// @dev See `LibExtrospectBytecode.isEOFBytecode`.
+    /// @param bytecode The bytecode to check.
+    /// @return True when the first two bytes of `bytecode` are `0xEF00`.
     function isEOFBytecode(bytes memory bytecode) external pure returns (bool);
 
-    /// @notice See `LibExtrospectERC1167Proxy.isERC1167Proxy`.
+    /// @notice Whether `bytecode` is the 45 byte ERC-1167 minimal proxy, and
+    /// the implementation address embedded in it when it is. Never reverts,
+    /// and performs no EOF check.
+    /// @dev See `LibExtrospectERC1167Proxy.isERC1167Proxy`.
+    /// @param bytecode The bytecode to check.
+    /// @return True when `bytecode` is exactly 45 bytes and carries the
+    /// ERC-1167 prefix and suffix.
+    /// @return The 20 bytes at offset 10 of `bytecode` read as an address, or
+    /// the zero address when the first return is false.
     function isERC1167Proxy(bytes memory bytecode) external pure returns (bool, address);
 
-    /// @notice See `LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode`.
+    /// @notice Bitmap of every opcode byte a linear scan of `bytecode` reads,
+    /// skipping the inline data of `PUSH*` opcodes. Regions that never execute,
+    /// such as trailing metadata, still set bits. Reverts
+    /// `EOFBytecodeNotSupported` when `bytecode` is EOF.
+    /// @dev See `LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode`.
+    /// @param bytecode The bytecode to scan.
+    /// @return A bitmap, not a count: bit `N` is set when opcode `N` was read.
     function scanEVMOpcodesPresentInBytecode(bytes memory bytecode) external pure returns (uint256);
 
-    /// @notice See `LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode`.
+    /// @notice Bitmap of the opcodes a linear scan of `bytecode` treats as
+    /// reachable. The scan skips the inline data of `PUSH*` opcodes, pauses at
+    /// each halting opcode (`STOP`, `JUMP`, `RETURN`, `REVERT`, `INVALID`,
+    /// `SELFDESTRUCT`) and resumes at the next `JUMPDEST`, so bytes between a
+    /// halt and the next `JUMPDEST` set no bits. Reachability is
+    /// over-approximated: a `JUMPDEST` that no execution path can reach still
+    /// resumes the scan. Reverts `EOFBytecodeNotSupported` when `bytecode` is
+    /// EOF.
+    /// @dev See `LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode`.
+    /// @param bytecode The bytecode to scan.
+    /// @return A bitmap, not a count: bit `N` is set when opcode `N` was
+    /// scanned as reachable.
     function scanEVMOpcodesReachableInBytecode(bytes memory bytecode) external pure returns (uint256);
 
-    /// @notice See `LibExtrospectMetamorphic.scanMetamorphicRisk`.
+    /// @notice Bitmap of the metamorphic risk opcodes
+    /// (`SELFDESTRUCT`, `DELEGATECALL`, `CALLCODE`, `CREATE`, `CREATE2`) that
+    /// `scanEVMOpcodesReachableInBytecode` finds reachable in `bytecode`.
+    /// Reverts `EOFBytecodeNotSupported` when `bytecode` is EOF.
+    /// @dev See `LibExtrospectMetamorphic.scanMetamorphicRisk`.
+    /// @param bytecode The bytecode to scan.
+    /// @return A bitmap, not a count or a score: bit `N` is set when
+    /// metamorphic opcode `N` is reachable. Zero when none are.
     function scanMetamorphicRisk(bytes memory bytecode) external pure returns (uint256);
 
-    /// @notice See `LibExtrospectBytecode.tryTrimSolidityCBORMetadata`.
+    /// @notice Removes the last 53 bytes of `bytecode` when they are the exact
+    /// Solidity CBOR metadata structure the trimmer recognises. Metadata in any
+    /// other shape is not trimmed and does not revert. Reverts
+    /// `EOFBytecodeNotSupported` when `bytecode` is EOF.
+    /// @dev See `LibExtrospectBytecode.tryTrimSolidityCBORMetadata`, which
+    /// takes `bytes memory` and trims it in place. Across this external
+    /// interface the argument is a copy in the callee's memory, so the caller's
+    /// own `bytecode` is untouched and the trimmed bytes come back as
+    /// `trimmedBytecode`.
+    /// @param bytecode The bytecode to trim.
+    /// @return didTrim True when the last 53 bytes matched and were removed.
+    /// @return trimmedBytecode `bytecode` less its last 53 bytes when `didTrim`
+    /// is true, otherwise `bytecode` unchanged.
     function tryTrimSolidityCBORMetadata(bytes memory bytecode)
         external
         pure


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/89

## What changed

`src/interface/IExtrospectV1.sol` only. Every one of the 12 functions goes from a
single `@notice See Lib….` line to full NatSpec: `@notice` describing what the
function does and every revert it can produce, `@dev` pointing at the library it
forwards to, `@param` for every parameter and `@return` for every return value.

The header sentence asserting "Function order matches the filesystem ordering of
the per-function test files under `test/src/concrete/Extrospect.<fn>.t.sol`" is
removed. It is a layout convention, not behaviour, and nothing enforces it.

Nothing else in the repo is touched. No verdict this library reaches changes:
the compiled artifacts are byte-identical, which `Extrospect.constants.t.sol`
(pinned creation bytecode, Zoltu address and runtime codehash) proves by staying
green — `bytecode_hash = "none"` and `cbor_metadata = false` mean comments never
reach the output.

### Hazards now visible at the layer consumers import

- `EOFBytecodeNotSupported` on `checkNotEOFBytecode`, `checkNotMetamorphic`,
  `scanEVMOpcodesPresentInBytecode`, `scanEVMOpcodesReachableInBytecode`,
  `scanMetamorphicRisk`, `tryTrimSolidityCBORMetadata`,
  `checkNoSolidityCBORMetadata` and `checkCBORTrimmedBytecodeHash`.
- `MetadataNotTrimmed` / `BytecodeHashMismatch` on `checkCBORTrimmedBytecodeHash`
  and `UnexpectedMetadata` on `checkNoSolidityCBORMetadata`, with the note that
  these errors are declared by the libraries, not by the interface.
- The three `uint256` returns are labelled as bitmaps, not counts or scores.
- `tryTrimSolidityCBORMetadata`'s library form trims in place; across this
  external interface the argument is a copy, so the trimmed bytes only come back
  through `trimmedBytecode`.
- The two `bytes32` "expected hash" parameters are each spelled out:
  `checkCBORTrimmedBytecodeHash`'s `expected` is the hash **after** the last 53
  bytes are removed; `isBeaconImplementationBytecode`'s `expectedRuntimeHash` is
  the hash of the runtime bytecode **as deployed**, untrimmed. That documents the
  two conventions, it does not reconcile them — #81 still owns that.
- `isERC1167Proxy` is marked as the one bytecode-taking entry point that never
  reverts and applies no EOF gate (#72's subject, documented not changed).

### Deliberately not written

The library claims the beacon predicates fold "any" call failure into `false`.
The interface instead enumerates the three conditions that actually produce
`false` (staticcall reverts, return length other than 32, top 12 bytes
non-zero). #77 is open against the "any reason" claim, so this PR does not carry
it forward into the interface.

## Test evidence

Toolchain: `nix develop -c forge test` / `nix develop -c forge fmt`, foundry
1.7.2-nightly, solc 0.8.25.

Two exclusions, per the harness facts established for this repo:

- `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol` needs
  `ARBITRUM_RPC_URL`, which is not set here. **Excluding the whole file loses all
  7 of its tests, of which only 3 are the fork tests that cannot run** — the
  other 4 are non-fork paths that would otherwise have been measured. That is
  exactly #85.
- `test/src/concrete/Extrospect.constants.t.sol` pins deployed bytecode, so it
  fails under every source mutation and would report KILLED for every mutant.
  Excluded from the mutation matrix **only**; it runs, and passes, in the
  before/after suite runs below, which is what proves this PR changes no
  bytecode.

Full suite, excluding only the fork file, on main and on this branch:

| run | result |
| --- | --- |
| main @ `32f7325` | 26 suites, **307 passed / 0 failed / 0 skipped** |
| this branch | 26 suites, **307 passed / 0 failed / 0 skipped** |

Baseline for the mutation matrix (both exclusions): 25 suites,
**304 passed / 0 failed**. Every mutant run below reported `304 total tests`, so
no mutant silently reduced the suite to nothing.

## Adversarial mutation pass

This is a documentation PR, so the mutation target is the documentation itself:
one mutant per behavioural claim the new NatSpec makes, breaking the source line
that claim rests on. A survivor would mean the interface now documents something
no test holds.

23 mutants, **23 killed, 0 survived**. Killing tests listed are the relevant
ones, not merely the first failure in the log.

| # | claim documented | mutation | file | killed by |
| --- | --- | --- | --- | --- |
| M01 | "Bytecode shorter than 2 bytes is not EOF" | length gate `>= 2` → `>= 3` | LibExtrospectBytecode | `testIsEOFBytecodeExactTwoBytes` |
| M02 | "begins with the EOF magic `0xEF00`" | magic `0xEF00` → `0xEF01` | LibExtrospectBytecode | `testCheckNotEOFBytecodeRevertsOnEOF` |
| M03 | `checkNotEOFBytecode` reverts on EOF | condition negated | LibExtrospectBytecode | `testCheckCBORTrimmedBytecodeHashEquivalenceRevertNotTrimmed` |
| M04 | "last 53 bytes" trim boundary | `length >= 53` → `>= 54` | LibExtrospectBytecode | `testTryTrimSolidityCBORMetadataExactly53BytesValid` |
| M05 | "Removes the last 53 bytes" | trims 52 not 53 | LibExtrospectBytecode | `testTryTrimSolidityCBORMetdataBytecodeReal` |
| M06 | `tryTrimSolidityCBORMetadata` reverts on EOF | EOF guard deleted | LibExtrospectBytecode | `testTryTrimSolidityCBORMetadataRevertsOnEOF` |
| M07 | reverts `MetadataNotTrimmed` when nothing trimmed | condition negated | LibExtrospectBytecode | `testCheckCBORTrimmedBytecodeHashEquivalenceRevertNotTrimmed` |
| M08 | reverts `BytecodeHashMismatch` on mismatch | condition negated | LibExtrospectBytecode | `testCheckCBORTrimmedBytecodeHashEquivalenceRevertHashMismatch` |
| M09 | reverts `UnexpectedMetadata` when metadata present | condition negated | LibExtrospectBytecode | `testCheckNoMetadataEmptyAccount` |
| M10 | present-scan "skipping the inline data of `PUSH*`" | PUSH skip deleted | LibExtrospectBytecode | `testScanEVMOpcodesPresentPush1` |
| M11 | reachable-scan "pauses at each halting opcode" | `halted := 1` → `:= 0` | LibExtrospectBytecode | `testScanEVMOpcodesReachableInvalid` |
| M12 | reachable-scan "resumes at the next `JUMPDEST`" | resume on `0x5C` not `0x5B` | LibExtrospectBytecode | `testCheckNotMetamorphicRevertsOnCreate2` |
| M13 | beacon: false on "return length other than 32" | `!= 32` → `< 32` | LibExtrospectERC1967BeaconProxy | `testReturnsFalseOnWrongLengthReturn` |
| M14 | beacon: false on "top 12 bytes non-zero" | dirty-bit rejection removed | LibExtrospectERC1967BeaconProxy | `testReturnsFalseOnInvalidReturnEncoding` |
| M15 | beacon: false when "the static call reverts" | success guard dropped | LibExtrospectERC1967BeaconProxy | `testReturnsFalseOnBeaconRevert` |
| M16 | `isBeaconOwner` compares equal to `expectedOwner` | `==` → `!=` | LibExtrospectERC1967BeaconProxy | `testMatchesAtMaxAddressBoundary` |
| M17 | "exactly 45 bytes" | `!=` → `<` | LibExtrospectERC1167Proxy | `testIsERC1167ProxyLength46` |
| M18 | "The 20 bytes at offset 10" | offset 10 → 11 | LibExtrospectERC1167Proxy | `testIsERC1167ProxyImplementationAddressIsCleanWord` |
| M19 | halting set includes `JUMP` | `JUMP` dropped from `HALTING_BITMAP` | EVMOpcodes | `testHaltingBitmapIndividualBits` |
| M20 | metamorphic set includes `CALLCODE` | `CALLCODE` dropped from `METAMORPHIC_OPS` | EVMOpcodes | `testMetamorphicOpsIndividualBits` |
| M21 | `scanMetamorphicRisk` is the reachable scan masked | mask removed | LibExtrospectMetamorphic | `testScanMetamorphicRiskClean` |
| M22 | `checkNotMetamorphic` reverts when the bitmap is non-zero | condition negated | LibExtrospectMetamorphic | `testCheckNotMetamorphicClean` |
| M23 | `trimmedBytecode` carries the trimmed bytes back | returns `hex""` | Extrospect (concrete) | `testTryTrimSolidityCBORMetadataEquivalenceTrim` |

Driver, mutant list and every per-mutant log are at
`/home/gildlab/artifacts/2026-08-18-extro-issues/i-89/.scratch/`
(`run-mutants.sh`, `mutants.txt`, `mutation-results.txt`, `mut-M*.log`). The
driver refuses to score a mutant whose `sed` matched nothing, whose build failed,
or whose run reported a test count other than 304, and it restores the file from
git after each one.

## Pre-existing failure seen during the run, not caused by this PR

`testCheckNoMetadataPassesFuzz(bytes)` fuzzed up `0xef01f53d…bf3` (60 bytes).
`vm.assume(!isEOFBytecode(code))` only excludes `0xEF00`, and Foundry rejects any
`0xEF01`-prefixed code that is not a 23-byte EIP-7702 delegation designator:

```
[FAIL: vm.etch: failed to create bytecode: Eip7702 is not 23 bytes long]
      testCheckNoMetadataPassesFuzz(bytes) (runs: 1496)
```

Once found it is cached in `cache/fuzz` and replayed on every later run, which is
why the 307/304 baselines above are clean and later runs are not. This is #86 and
#118, already filed; reproduced here on the unmodified tree with
`nix develop -c forge test --match-path
'test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol'` →
5 passed / 1 failed. No change in this PR.

## QA
- Discriminating tests: n/a — no new tests. The diff is NatSpec on
  `src/interface/IExtrospectV1.sol`; a test that asserted its prose would
  violate the standing ruling against tests that read documentation. The
  existing suite is the discriminator for the behaviour being documented, and
  the mutation matrix above is what shows it discriminates: 23 mutants, one per
  documented claim, 23 killed, 0 survived, every run reporting the full 304
  tests.
- Mutations applied: 23, all killed — full `line -> mutation -> killing test`
  table in the "Adversarial mutation pass" section above (M01 `bytecode.length
  >= 2` -> `>= 3` -> `testIsEOFBytecodeExactTwoBytes`, through M23
  `return (didTrim, bytecode)` -> `return (didTrim, hex"")` ->
  `testTryTrimSolidityCBORMetadataEquivalenceTrim`). Logs at
  `.scratch/mut-M*.log`.
- Oracle: the implementations themselves, read function by function
  (`LibExtrospectBytecode`, `LibExtrospectMetamorphic`, `LibExtrospectERC1167Proxy`,
  `LibExtrospectERC1967BeaconProxy`, `Extrospect`) plus the constants they
  depend on (`HALTING_BITMAP` = STOP/JUMP/RETURN/REVERT/INVALID/SELFDESTRUCT,
  `METAMORPHIC_OPS` = SELFDESTRUCT/DELEGATECALL/CALLCODE/CREATE/CREATE2,
  `ERC1167_PROXY_LENGTH` = 45, `ERC1167_IMPLEMENTATION_ADDRESS_OFFSET` = 10+20).
  Documentation describes current behaviour only; no claim is copied forward
  from existing prose. Each claim is then independently checked by the mutant
  that breaks it.
- Category check: #89 asks for (a) `@param` on every parameter, (b) `@return` on
  every return, (c) documented revert behaviour, (d) the `uint256` returns
  identified as bitmaps, (e) `tryTrimSolidityCBORMetadata`'s in-place-vs-copy
  behaviour, (f) the two `bytes32` hash conventions stated, (g) the untested
  function-ordering assertion in the file header. All seven covered — (g) by
  removing the assertion. The issue also mentions the beacon "any failure folds
  to false" claim; the interface enumerates the actual false conditions instead
  of restating it, because #77 owns that claim and this PR changes no verdict.
