### PR TITLE
Give the test oracles authorities independent of src

### DIFF
--- a/test/lib/LibExtrospectionSlow.sol
+++ b/test/lib/LibExtrospectionSlow.sol
@@ -2,9 +2,63 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {HALTING_BITMAP, METAMORPHIC_OPS, EVM_OP_JUMPDEST} from "src/lib/EVMOpcodes.sol";
-import {ERC1167_PREFIX_HASH, ERC1167_SUFFIX_HASH} from "src/lib/LibExtrospectERC1167Proxy.sol";
+/// @dev The 10 bytes before the implementation address in the ERC1167 minimal
+/// proxy runtime bytecode published at
+/// https://eips.ethereum.org/EIPS/eip-1167#specification
+bytes constant SLOW_ERC1167_PREFIX = hex"363d3d373d3d3d363d73";
 
+/// @dev The 15 bytes after the implementation address in the ERC1167 minimal
+/// proxy runtime bytecode published at
+/// https://eips.ethereum.org/EIPS/eip-1167#specification
+bytes constant SLOW_ERC1167_SUFFIX = hex"5af43d82803e903d91602b57fd5bf3";
+
+/// @dev The implementation address in an ERC1167 minimal proxy is 20 bytes.
+uint256 constant SLOW_ERC1167_ADDRESS_LENGTH = 20;
+
+/// @dev `JUMPDEST` opcode byte.
+uint8 constant SLOW_OP_JUMPDEST = 0x5B;
+
+/// @dev The first `PUSH*` opcode byte, `PUSH1`.
+uint8 constant SLOW_OP_PUSH1 = 0x60;
+
+/// @dev The last `PUSH*` opcode byte, `PUSH32`.
+uint8 constant SLOW_OP_PUSH32 = 0x7F;
+
+/// @dev Opcode bytes that halt the current execution path: `STOP`, `JUMP`,
+/// `RETURN`, `REVERT`, `INVALID`, `SELFDESTRUCT`.
+uint256 constant SLOW_HALTING_BITMAP =
+//forge-lint: disable-next-line(incorrect-shift)
+ (uint256(1) << 0x00)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0x56)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xF3)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xFD)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xFE)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xFF);
+
+/// @dev Opcode bytes that indicate metamorphic risk: `SELFDESTRUCT`,
+/// `DELEGATECALL`, `CALLCODE`, `CREATE`, `CREATE2`.
+uint256 constant SLOW_METAMORPHIC_BITMAP =
+//forge-lint: disable-next-line(incorrect-shift)
+ (uint256(1) << 0xFF)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xF4)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xF2)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xF0)
+    //forge-lint: disable-next-line(incorrect-shift)
+    | (uint256(1) << 0xF5);
+
+/// @title LibExtrospectionSlow
+/// @notice Reference implementations used as differential oracles for
+/// `src`. Every opcode byte, bitmap and bytecode literal used here is
+/// declared in this file from the published EVM and ERC specifications, so
+/// `src` and the oracle share no state.
 library LibExtrospectionSlow {
     /// KISS implementation of isEOFBytecode.
     //forge-lint: disable-next-line(mixed-case-function)
@@ -18,39 +72,60 @@ library LibExtrospectionSlow {
         return isEOF;
     }
 
-    /// KISS implementation of a presence scan.
+    /// Decodes `data` to the sequence of opcode bytes it contains, dropping
+    /// the inline data bytes that follow each `PUSH*`. A `PUSH*` whose inline
+    /// data runs past the end of `data` contributes only itself.
+    /// @param data The bytecode to decode.
+    /// @return ops The opcode bytes in the order they appear.
+    function decodeOpcodesSlow(bytes memory data) internal pure returns (bytes memory ops) {
+        bytes memory buffer = new bytes(data.length);
+        uint256 count = 0;
+        uint256 i = 0;
+        while (i < data.length) {
+            uint8 op = uint8(data[i]);
+            buffer[count] = bytes1(op);
+            count++;
+            if (SLOW_OP_PUSH1 <= op && op <= SLOW_OP_PUSH32) {
+                i += uint256(op) - uint256(SLOW_OP_PUSH1) + 1;
+            }
+            i++;
+        }
+        ops = new bytes(count);
+        for (uint256 j = 0; j < count; j++) {
+            ops[j] = buffer[j];
+        }
+    }
+
+    /// KISS implementation of a presence scan. Every decoded opcode is
+    /// present.
     //forge-lint: disable-next-line(mixed-case-function)
     function scanEVMOpcodesPresentInBytecodeSlow(bytes memory data) internal pure returns (uint256) {
+        bytes memory ops = decodeOpcodesSlow(data);
         uint256 scan = 0;
-        for (uint256 i = 0; i < data.length; i++) {
-            uint8 op = uint8(data[i]);
-            scan = scan | (uint256(1) << uint256(op));
-
-            if (0x60 <= op && op < 0x80) {
-                i += op - 0x5f;
-            }
+        for (uint256 i = 0; i < ops.length; i++) {
+            scan = scan | opcodeBit(uint8(ops[i]));
         }
         return scan;
     }
 
-    /// KISS implementation of a reachability scan.
+    /// KISS implementation of a reachability scan. Decoded opcodes are
+    /// reachable until a halting opcode, and reachable again from the next
+    /// `JUMPDEST`.
     //forge-lint: disable-next-line(mixed-case-function)
     function scanEVMOpcodesReachableInBytecodeSlow(bytes memory data) internal pure returns (uint256) {
+        bytes memory ops = decodeOpcodesSlow(data);
         uint256 scan = 0;
-        bool halted = false;
-        for (uint256 i = 0; i < data.length; i++) {
-            uint8 op = uint8(data[i]);
-            if (0x60 <= op && op < 0x80) {
-                i += op - 0x5f;
-            }
-            if (!halted) {
-                scan = scan | (uint256(1) << uint256(op));
-                if ((HALTING_BITMAP & (uint256(1) << uint256(op))) > 0) {
-                    halted = true;
+        bool reachable = true;
+        for (uint256 i = 0; i < ops.length; i++) {
+            uint8 op = uint8(ops[i]);
+            if (reachable) {
+                scan = scan | opcodeBit(op);
+                if ((SLOW_HALTING_BITMAP & opcodeBit(op)) != 0) {
+                    reachable = false;
                 }
-            } else if (op == EVM_OP_JUMPDEST) {
-                halted = false;
-                scan = scan | (uint256(1) << uint256(op));
+            } else if (op == SLOW_OP_JUMPDEST) {
+                reachable = true;
+                scan = scan | opcodeBit(op);
             }
         }
         return scan;
@@ -58,44 +133,46 @@ library LibExtrospectionSlow {
 
     /// KISS implementation of metamorphic risk scan.
     function scanMetamorphicRiskSlow(bytes memory data) internal pure returns (uint256) {
-        return scanEVMOpcodesReachableInBytecodeSlow(data) & METAMORPHIC_OPS;
+        return scanEVMOpcodesReachableInBytecodeSlow(data) & SLOW_METAMORPHIC_BITMAP;
     }
 
-    /// KISS implementation of ERC1167 proxy detection.
+    /// KISS implementation of ERC1167 proxy detection. Compares the bytecode
+    /// byte for byte against the published minimal proxy runtime.
     function isERC1167ProxySlow(bytes memory bytecode)
         internal
         pure
         returns (bool result, address implementationAddress)
     {
-        if (bytecode.length != 45) {
+        bytes memory prefix = SLOW_ERC1167_PREFIX;
+        bytes memory suffix = SLOW_ERC1167_SUFFIX;
+
+        if (bytecode.length != prefix.length + SLOW_ERC1167_ADDRESS_LENGTH + suffix.length) {
             return (false, address(0));
         }
 
-        bytes memory bytecodePrefix = new bytes(10);
-        for (uint256 i = 0; i < 10; i++) {
-            bytecodePrefix[i] = bytecode[i];
-        }
-        bytes memory bytecodeSuffix = new bytes(15);
-        for (uint256 i = 0; i < 15; i++) {
-            bytecodeSuffix[i] = bytecode[30 + i];
+        for (uint256 i = 0; i < prefix.length; i++) {
+            if (bytecode[i] != prefix[i]) {
+                return (false, address(0));
+            }
         }
 
-        if (keccak256(bytecodePrefix) != ERC1167_PREFIX_HASH) {
-            return (false, address(0));
+        for (uint256 i = 0; i < suffix.length; i++) {
+            if (bytecode[prefix.length + SLOW_ERC1167_ADDRESS_LENGTH + i] != suffix[i]) {
+                return (false, address(0));
+            }
         }
 
-        if (keccak256(bytecodeSuffix) != ERC1167_SUFFIX_HASH) {
-            return (false, address(0));
+        uint160 accumulator = 0;
+        for (uint256 i = 0; i < SLOW_ERC1167_ADDRESS_LENGTH; i++) {
+            accumulator = (accumulator << 8) | uint160(uint8(bytecode[prefix.length + i]));
         }
+        return (true, address(accumulator));
+    }
 
-        bytes memory implementationAddressBytes = new bytes(20);
-        for (uint256 i = 0; i < 20; i++) {
-            implementationAddressBytes[i] = bytecode[10 + i];
-        }
-        uint256 implementationAddressMask = type(uint160).max;
-        assembly {
-            implementationAddress := and(mload(add(implementationAddressBytes, 20)), implementationAddressMask)
-        }
-        return (true, implementationAddress);
+    /// The bit representing `op` in an opcode bitmap.
+    /// @param op The opcode byte.
+    /// @return The bitmap with only the bit for `op` set.
+    function opcodeBit(uint8 op) internal pure returns (uint256) {
+        return uint256(1) << uint256(op);
     }
 }

--- a/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
@@ -7,11 +7,46 @@ import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
 import {NonMetamorphic} from "test/concrete/NonMetamorphic.sol";
 import {SOLIDITY_CBOR_RUNTIME_FIXTURE} from "test/concrete/SolidityCBORFixture.sol";
 
+/// @dev Total length of standard Solidity CBOR metadata, from the CBOR map
+/// header to the 2 byte length suffix.
+/// https://docs.soliditylang.org/en/latest/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode
+uint256 constant SOLIDITY_CBOR_METADATA_LENGTH = 53;
+
 contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
     /// External wrapper for revert tests.
     //forge-lint: disable-next-line(mixed-case-function)
     function checkNoSolidityCBORMetadataExternal(address account) external view {
         LibExtrospectBytecode.checkNoSolidityCBORMetadata(account);
+    }
+
+    /// Builds standard Solidity CBOR metadata: CBOR map header, the `ipfs`
+    /// key and its 34 byte value, the `solc` key and its 3 byte value, and
+    /// the 2 byte length suffix. The IPFS hash and solc version bytes are
+    /// filled from `seed`.
+    /// @param seed Source of the per-contract bytes.
+    /// @return The 53 bytes of metadata.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function solidityCBORMetadata(bytes32 seed) internal pure returns (bytes memory) {
+        bytes memory ipfsHash = new bytes(34);
+        for (uint256 i = 0; i < ipfsHash.length; i++) {
+            ipfsHash[i] = seed[i % 32];
+        }
+        bytes memory solcVersion = new bytes(3);
+        for (uint256 i = 0; i < solcVersion.length; i++) {
+            solcVersion[i] = seed[i];
+        }
+        return bytes.concat(hex"a264697066735822", ipfsHash, hex"64736f6c6343", solcVersion, hex"0033");
+    }
+
+    /// The offsets within standard Solidity CBOR metadata of the bytes that
+    /// are the same for every contract: `a2 64 "ipfs" 5822` at 0-7,
+    /// `64 "solc" 43` at 42-47, and the 2 byte length suffix at 51-52. The
+    /// bytes at every other offset are the IPFS hash and the solc version,
+    /// which differ per contract.
+    /// @return offsets The offsets, ascending.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function solidityCBORMetadataFixedOffsets() internal pure returns (uint256[16] memory offsets) {
+        offsets = [uint256(0), 1, 2, 3, 4, 5, 6, 7, 42, 43, 44, 45, 46, 47, 51, 52];
     }
 
     /// Account with no code passes (no metadata to detect).
@@ -45,14 +80,39 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
         this.checkNoSolidityCBORMetadataExternal(target);
     }
 
-    /// Fuzz: bytecode without valid metadata passes.
-    function testCheckNoMetadataPassesFuzz(bytes memory code) external {
-        vm.assume(code.length > 0);
-        vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
-        vm.assume(!LibExtrospectBytecode.tryTrimSolidityCBORMetadata(code));
+    /// Fuzz: bytecode shorter than Solidity CBOR metadata passes. The
+    /// leading `STOP` keeps the bytecode out of the EOF format.
+    function testCheckNoMetadataPassesShortBytecode(bytes memory code) external {
+        uint256 length = code.length;
+        if (length >= SOLIDITY_CBOR_METADATA_LENGTH) {
+            length = SOLIDITY_CBOR_METADATA_LENGTH - 1;
+        }
+        bytes memory short = new bytes(length);
+        for (uint256 i = 0; i < length; i++) {
+            short[i] = code[i];
+        }
+        if (length > 0) {
+            short[0] = 0x00;
+        }
 
         address target = address(0xBEEF);
-        vm.etch(target, code);
+        vm.etch(target, short);
+        LibExtrospectBytecode.checkNoSolidityCBORMetadata(target);
+    }
+
+    /// Fuzz: bytecode ending in Solidity CBOR metadata with exactly one of
+    /// its fixed structure bytes corrupted passes. The leading `STOP` keeps
+    /// the bytecode out of the EOF format.
+    function testCheckNoMetadataPassesCorruptedMetadata(bytes memory code, uint256 offsetIndex, uint8 corruption)
+        external
+    {
+        uint256[16] memory offsets = solidityCBORMetadataFixedOffsets();
+        uint256 offset = offsets[bound(offsetIndex, 0, offsets.length - 1)];
+        bytes memory metadata = solidityCBORMetadata(keccak256(code));
+        metadata[offset] = bytes1(uint8(metadata[offset]) ^ uint8(bound(corruption, 1, type(uint8).max)));
+
+        address target = address(0xBEEF);
+        vm.etch(target, bytes.concat(hex"00", code, metadata));
         LibExtrospectBytecode.checkNoSolidityCBORMetadata(target);
     }
 
@@ -60,20 +120,7 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
     function testCheckNoMetadataRevertsFuzz(bytes memory code) external {
         vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
 
-        // Build synthetic IPFS hash and solc version from fuzz input.
-        bytes32 seed = keccak256(code);
-        bytes memory ipfsHash = new bytes(34);
-        assembly ("memory-safe") {
-            mstore(add(ipfsHash, 0x20), seed)
-            mstore(add(ipfsHash, 0x40), keccak256(0, 0x20))
-        }
-        bytes memory solcVersion = new bytes(3);
-        assembly ("memory-safe") {
-            mstore(add(solcVersion, 0x20), seed)
-        }
-
-        bytes memory withMetadata =
-            bytes.concat(code, hex"a264697066735822", ipfsHash, hex"64736f6c6343", solcVersion, hex"0033");
+        bytes memory withMetadata = bytes.concat(code, solidityCBORMetadata(keccak256(code)));
 
         address target = address(0xBEEF);
         vm.etch(target, withMetadata);

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.slots.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.slots.t.sol
@@ -9,22 +9,36 @@ import {
     ERC1967_BEACON_SLOT
 } from "src/lib/LibExtrospectERC1967BeaconProxy.sol";
 
+/// @dev The implementation slot literal published in EIP-1967.
+/// https://eips.ethereum.org/EIPS/eip-1967#logic-contract-address
+bytes32 constant EIP1967_PUBLISHED_IMPLEMENTATION_SLOT =
+    0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+/// @dev The admin slot literal published in EIP-1967.
+/// https://eips.ethereum.org/EIPS/eip-1967#admin-address
+bytes32 constant EIP1967_PUBLISHED_ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+/// @dev The beacon slot literal published in EIP-1967.
+/// https://eips.ethereum.org/EIPS/eip-1967#beacon-contract-address
+bytes32 constant EIP1967_PUBLISHED_BEACON_SLOT = 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50;
+
 /// @title LibExtrospectERC1967BeaconProxySlotsTest
-/// @notice Pins the EIP-1967 slot constant derivations.
+/// @notice Pins the EIP-1967 slot constants to the slot literals published in
+/// EIP-1967.
 contract LibExtrospectERC1967BeaconProxySlotsTest is Test {
-    /// `ERC1967_IMPLEMENTATION_SLOT` matches `keccak256("eip1967.proxy.implementation") - 1`.
-    function testImplementationSlotMatchesDerivation() external pure {
-        assertEq(ERC1967_IMPLEMENTATION_SLOT, bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1));
+    /// `ERC1967_IMPLEMENTATION_SLOT` equals the published implementation slot.
+    function testImplementationSlotMatchesPublishedLiteral() external pure {
+        assertEq(ERC1967_IMPLEMENTATION_SLOT, EIP1967_PUBLISHED_IMPLEMENTATION_SLOT);
     }
 
-    /// `ERC1967_ADMIN_SLOT` matches `keccak256("eip1967.proxy.admin") - 1`.
-    function testAdminSlotMatchesDerivation() external pure {
-        assertEq(ERC1967_ADMIN_SLOT, bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1));
+    /// `ERC1967_ADMIN_SLOT` equals the published admin slot.
+    function testAdminSlotMatchesPublishedLiteral() external pure {
+        assertEq(ERC1967_ADMIN_SLOT, EIP1967_PUBLISHED_ADMIN_SLOT);
     }
 
-    /// `ERC1967_BEACON_SLOT` matches `keccak256("eip1967.proxy.beacon") - 1`.
-    function testBeaconSlotMatchesDerivation() external pure {
-        assertEq(ERC1967_BEACON_SLOT, bytes32(uint256(keccak256("eip1967.proxy.beacon")) - 1));
+    /// `ERC1967_BEACON_SLOT` equals the published beacon slot.
+    function testBeaconSlotMatchesPublishedLiteral() external pure {
+        assertEq(ERC1967_BEACON_SLOT, EIP1967_PUBLISHED_BEACON_SLOT);
     }
 
     /// The three EIP-1967 slots are pairwise distinct.


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/87

Every oracle named in the issue is a test-side oracle, so nothing here changes what the library concludes about any contract. The EIP-1967 slots, the ERC1167 prefix/suffix, both opcode bitmaps and the metadata trimmer all hold the same values before and after; only what the tests compare them against changed.

## Verified against `main` @ `32f7325`

| Issue item | Reproduced |
| --- | --- |
| 1. `slots.t.sol` restates the derivation expression | Yes — all three tests asserted `constant == keccak256(seed) - 1`, the same expression `src` uses. |
| 2. `LibExtrospectionSlow` imports `HALTING_BITMAP`, `METAMORPHIC_OPS`, `EVM_OP_JUMPDEST`, `ERC1167_PREFIX_HASH`, `ERC1167_SUFFIX_HASH` from `src` | Yes — lines 5-6 of the file. Mutation M2/M5/M6 below measure the consequence. |
| 3. The slow reachability scan transcribes the assembly | Yes for structure. Not fixable by a differential: see "What is not fixed". |
| 4. `testCheckNoMetadataPassesFuzz` guards with the function under test | Yes — `vm.assume(!tryTrimSolidityCBORMetadata(code))` then asserts `checkNoSolidityCBORMetadata` passes, and `checkNoSolidityCBORMetadata` *is* `tryTrimSolidityCBORMetadata`. |
| 5. `testOpcodeValues` restates the `src` hex literals | Yes, and as the issue says the values are correct through Cancun. No change: an opcode constant has no authority expressible in Solidity beyond its literal, and adding hardfork opcodes would move a verdict. |

## What changed

**EIP-1967 slots** — the three tests now pin the slot literals published in EIP-1967 instead of the derivation. The literals are declared as named constants with the spec section they come from.

**`LibExtrospectionSlow`** — the file no longer imports anything from `src`. It declares the ERC1167 runtime prefix/suffix, `JUMPDEST`, the `PUSH1`/`PUSH32` bounds, the halting bitmap and the metamorphic bitmap from the published EVM and ERC specs. `isERC1167ProxySlow` compares the bytecode byte for byte against its own copy of the published minimal proxy runtime rather than hashing against `src`'s hashes, and accumulates the implementation address a byte at a time instead of an `mload`. The presence and reachability scans now share one `decodeOpcodesSlow` pass that drops `PUSH*` inline data, and classify from the decoded stream.

**`checkNoSolidityCBORMetadata` fuzz** — the self-referential `vm.assume` is gone. Two constructed negatives replace it:
- `testCheckNoMetadataPassesShortBytecode` — bytecode truncated below the 53-byte metadata length.
- `testCheckNoMetadataPassesCorruptedMetadata` — metadata built from the documented layout with exactly one of its 16 fixed structure bytes XOR-corrupted. Every one of those 16 offsets is inside the trimmer's masks, so each is asserted to be load-bearing.

The metadata builder is shared with `testCheckNoMetadataRevertsFuzz`, which asserts the uncorrupted output of the same builder *does* trim. That pairing is what stops the corrupted case being vacuous.

## What is not fixed

Item 3's residue. A hand-written reference derived from the same prose as `src` can never be an independent authority for that prose — M9 and M10 below show that a `src`-only edit already breaks agreement, so the transcription similarity was never hiding `src` mutations. What it cannot see is a shared misreading, and the live instance of that class is whether an undefined opcode halts, which is https://github.com/rainlanguage/rain.extrospection/issues/56 and would move a verdict. Not touched here.

## Baseline

`nix develop -c forge test`, this machine, `ARBITRUM_RPC_URL` absent:

- `main` unfiltered: 311 passed / 3 failed / 314 total. The 3 failures are `LibExtrospectBytecodeCheckCBORTrimmedBytecodeHashTest` fork tests with no RPC URL (https://github.com/rainlanguage/rain.extrospection/issues/85).
- This branch, excluding `test/src/lib/LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.t.sol`: **308 passed / 0 failed** (`main`: 307). That exclusion drops all 7 tests in the file, not just the 3 fork tests — the four non-fork paths go unmeasured, which is #85.
- Mutation baseline, additionally excluding `ExtrospectConstantsTest`: **branch 305 / 0 failed, `main` 304 / 0 failed**. `ExtrospectConstantsTest` pins deployed bytecode so it fails under every source mutation and would report KILLED for every mutant (https://github.com/rainlanguage/rain.extrospection/issues/84).

## Adversarial mutation pass

Every mutant applied to `src` only (M2 additionally co-mutates the test copy of the derivation, which is the failure mode item 1 describes). Each case ran the full filtered suite from a cleared `cache/fuzz`. `main` column = this branch's `src` with the three test files restored from `main`, so the only variable is the oracle.

| # | Mutation | `main` tests | branch tests | Verdict |
| --- | --- | --- | --- | --- |
| M0 | none (control) | 304 pass / 0 fail | 305 pass / 0 fail | baseline |
| M1 | `eip1967.proxy.implementation` seed string in `src` | KILLED `testImplementationSlotMatchesDerivation` | KILLED `testImplementationSlotMatchesPublishedLiteral` | unchanged |
| M2 | same seed string mis-copied into **both** `src` and the test | **SURVIVED** | **KILLED** `testImplementationSlotMatchesPublishedLiteral` | **gained** |
| M3 | `ERC1167_PREFIX` last byte `73`→`74` | KILLED `testERC1167Constants` | KILLED `testERC1167Constants`, `testIsERC1167ProxySlowSuccess` | differential now sees it |
| M4 | `ERC1167_SUFFIX` last byte `f3`→`f4` | KILLED `testERC1167Constants` | KILLED `testERC1167Constants`, `testIsERC1167ProxySlowSuccess` | differential now sees it |
| M5 | `HALTING_BITMAP` drops `JUMP` | KILLED, 4 tests, no differential | KILLED, 6 tests incl. `testScanEVMOpcodesReachableReference`, `testScanMetamorphicRiskReference` | differential now sees it |
| M6 | `METAMORPHIC_OPS` drops `CREATE2` | KILLED, 5 tests, no differential | KILLED, 6 tests incl. `testScanMetamorphicRiskReference` | differential now sees it |
| M7 | `EVM_OP_JUMPDEST` `0x5B`→`0x5C` | KILLED, 80 tests, no differential | KILLED, 82 tests incl. both differentials | differential now sees it |
| M8 | metadata hash comparison weakened to its low byte (`eq(h, e)` → `eq(and(h,0xFF), and(e,0xFF))`) | **SURVIVED** | **KILLED** `testCheckNoMetadataPassesCorruptedMetadata` | **gained** |
| M9 | reachable scan stops skipping `PUSH32` inline data | KILLED, 5 tests incl. both differentials | KILLED, 5 tests incl. both differentials | unchanged |
| M10 | reachable scan never resumes at `JUMPDEST` | KILLED, 81 tests | KILLED, 81 tests | unchanged |

Two survivors on `main` are kills on this branch; no mutant regressed. M2 is item 1's exact scenario and M8 is item 4's: on `main` the metadata "passes" fuzz cannot kill any mutation of its own oracle, because `vm.assume` filters out precisely the inputs that would have exposed it.

M9/M10 are the item 3 probes: the reference already kills `src`-only algorithm edits, on both `main` and this branch.

Proof the tests ran, not just compiled — M0 control and one gained kill:

```
=== MUTANT M0-control-unmutated (branch2) ===
Ran 25 test suites: 305 tests passed, 0 failed, 0 skipped (305 total tests)

=== MUTANT M8-metadata-hash-compare-low-byte (main) ===
 src/lib/LibExtrospectBytecode.sol | 2 +-
Ran 25 test suites: 304 tests passed, 0 failed, 0 skipped (304 total tests)

=== MUTANT M8-metadata-hash-compare-low-byte (branch2) ===
 src/lib/LibExtrospectBytecode.sol | 2 +-
Ran 25 test suites: 304 tests passed, 1 failed, 0 skipped (305 total tests)
[FAIL: UnexpectedMetadata(); counterexample: ...] testCheckNoMetadataPassesCorruptedMetadata(bytes,uint256,uint8) (runs: 125)
```

An earlier mutation pass, run without clearing `cache/fuzz` between cases, hit `vm.etch: failed to create bytecode: Eip7702 is not 23 bytes long` in the pre-existing `testCheckNoMetadataRevertsFuzz` and then replayed it stickily — https://github.com/rainlanguage/rain.extrospection/issues/86 and https://github.com/rainlanguage/rain.extrospection/issues/118, untouched here. Both new fuzz tests prefix a `STOP` byte, so neither can generate a delegation designator or an EOF prefix.

## QA
- Discriminating tests: `testImplementationSlotMatchesPublishedLiteral`, `testAdminSlotMatchesPublishedLiteral`, `testBeaconSlotMatchesPublishedLiteral`, `testCheckNoMetadataPassesCorruptedMetadata`, `testCheckNoMetadataPassesShortBytecode`; plus `testIsERC1167ProxySlowSuccess`, `testIsERC1167ProxySlowFail`, `testScanEVMOpcodesReachableReference`, `testScanMetamorphicRiskReference`, unchanged in body but now differential against constants `src` does not supply. Verified against base by re-running every mutant with the three test files restored from `main`: M2 and M8 pass on base and fail here (table above).
- Mutations applied: 10, all `src`-only except M2 which is a deliberate co-mutation. `LibExtrospectERC1967BeaconProxy.sol` slot seed string, mis-copied into both `src` and the test -> SURVIVED on base, KILLED here by `testImplementationSlotMatchesPublishedLiteral`. `LibExtrospectBytecode.sol` `didTrim := eq(relevantHash, expectedHash)` -> `eq(and(relevantHash,0xFF), and(expectedHash,0xFF))` -> SURVIVED on base, KILLED here by `testCheckNoMetadataPassesCorruptedMetadata`. `LibExtrospectERC1167Proxy.sol` prefix byte `73`->`74` and suffix byte `f3`->`f4` -> killed on both by `testERC1167Constants`, newly also by `testIsERC1167ProxySlowSuccess`. `EVMOpcodes.sol` `HALTING_BITMAP` drops `JUMP`, `METAMORPHIC_OPS` drops `CREATE2`, `EVM_OP_JUMPDEST` `0x5B`->`0x5C` -> killed on both, newly also by the differential fuzz tests. `LibExtrospectBytecode.sol` `lt(push, 0x20)` -> `lt(push, 0x1F)` and deleted `halted := 0` -> killed identically on both.
- Oracle: EIP-1967's published implementation/admin/beacon slot literals; EIP-1167's published minimal proxy runtime bytes; the published EVM opcode bytes for `JUMPDEST`, `PUSH1`, `PUSH32` and for the halting and metamorphic sets; the Solidity metadata layout documented at docs.soliditylang.org. Each is declared in the test tree, so no oracle reads a `src` constant.
- Category check: issue lists 5 items. Covered 1 (EIP-1967 literals pinned), 2 (`LibExtrospectionSlow` declares its own constants), 4 (constructed negatives replace the self-referential `vm.assume`). Item 3 covered for constants and structure; its residue is named above and left to https://github.com/rainlanguage/rain.extrospection/issues/56 because closing it moves a verdict. Item 5 is "nothing to change" in the issue itself and stays unchanged for the same reason.
