### PR TITLE
Bump rain-math-binary 0.1.3 -> 0.1.4

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -31,7 +31,7 @@ no_match_contract = "ExtrospectConstantsTest"
 [dependencies]
 forge-std = "1.16.1"
 "rain-solmem" = "0.1.3"
-"rain-math-binary" = "0.1.3"
+"rain-math-binary" = "0.1.4"
 "rain-deploy" = "0.1.3"
 
 [soldeer]

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -14,10 +14,10 @@ integrity = "10bff708d9e5d8b77655b8a8fc0c755cef8e3fc876cc3ff100425d27b08294a0"
 
 [[dependencies]]
 name = "rain-math-binary"
-version = "0.1.3"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-binary/0_1_3_19-07-2026_19:05:36_rain.math.zip"
-checksum = "0e9bd1e311999215baea944a292e241d1ed40ff9649c693cc9f125c9145808ab"
-integrity = "43557e24ad5bff04079460e5f1a550087df5b47f04fa63ff18c713fcec6a8289"
+version = "0.1.4"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-binary/0_1_4_17-08-2026_05:22:01_rain.math.zip"
+checksum = "1787eb0bc883c4922deb5e547ecaf0bd0f9a31e99c51f3b11744c3324eb592f6"
+integrity = "857d22060d058ec173e88448c2d44f0cb884b2381669d0dbe1d3bebb168715ea"
 
 [[dependencies]]
 name = "rain-solmem"

--- a/test/src/lib/EVMOpcodes.t.sol
+++ b/test/src/lib/EVMOpcodes.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibCtPop} from "rain-math-binary-0.1.3/src/lib/LibCtPop.sol";
+import {LibCtPop} from "rain-math-binary-0.1.4/src/lib/LibCtPop.sol";
 
 import {
     EVM_OP_STOP,


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.extrospection/issues/129

Moves `rain-math-binary` from 0.1.3 to 0.1.4 — `foundry.toml`, the `soldeer.lock` entry, and the one import that names the version, in `test/src/lib/EVMOpcodes.t.sol`. This repo has no `remappings.txt`, so nothing else carries the version string.

Usage here is **test-only**: `LibCtPop` appears in that one test file and nowhere under `src/`, so nothing that ships changes.

`soldeer.lock` was regenerated with `forge soldeer update`; the diff is 4 lines, the `rain-math-binary` entry alone — no other dependency moved.

## No behaviour change

`rain.math.binary/src/` has changed exactly once since 2024: `90244afc` (2026-07-18), NatSpec on `ctpop`/`ctpopSlow` and a comment correction. So 0.1.3 to 0.1.4 is a version move, not a fix. The reason to take it is convergence — the org currently carries two pins of a one-library package (0.1.1 in `rainlang`, 0.1.3 here and in `rainlang.interface`), and unifying them makes the next bump a single coordinated move.

## QA
- Discriminating tests: n/a — a version string and an import path changed, so there is no behaviour to discriminate. The existing suite is the regression check: 312 passed, 3 failed, the three being `LibExtrospectBytecode.checkCBORTrimmedBytecodeHash.fork.t.sol` needing `ARBITRUM_RPC_URL`, which is environmental and fails identically on `main`.
- Mutations applied: n/a — no source or test logic changed; there is no line whose behaviour a mutant could alter.
- Oracle: `rain.math.binary`'s own history for the no-behaviour-change claim (`git log -- src/` shows `90244afc` as the only change since 2024), and `soldeer.lock`'s checksum and integrity for the identity of the revision installed.
- Category check: #129 asks for the bump to 0.1.4; covered — `foundry.toml`, `soldeer.lock` and the single import site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rain Math Binary package to version 0.1.4.
  * Updated associated test references to maintain compatibility with the latest package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->