### PR TITLE
Bump [external.package] version to 0.1.7 to un-red the release lane

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
 # ignores.
 [external.package]
 name = "rain-extrospection"
-version = "0.1.6"
+version = "0.1.7"
 
 [profile.default]
 


### PR DESCRIPTION
Every push to main currently fails the "Package Release" workflow with:

> `foundry.toml [package].version (0.1.6) is not ahead of the published revision (0.1.6) — bump [package].version above 0.1.6.`

Soldeer already has rain-extrospection 0.1.6 published (2026-08-18). That 0.1.6 was published pre-split — it still contains the concrete — so the post-split library half of this repo has never published. rainix-autopublish requires `foundry.toml [external.package] version` to be the next unpublished version, so main's `0.1.6` reds the lane on every push.

This PR bumps that one line to `0.1.7`, nothing else. It un-reds the lane so the next merge to main publishes 0.1.7 — the "release lane publishes cleanly" checkbox of https://github.com/rainlanguage/rain.extrospection/issues/46.

## QA
- Discriminating tests: n/a — one-line release-metadata bump in foundry.toml; no Solidity/behavioral change, nothing a repo test can discriminate. The discriminating check is the Package Release workflow itself, which fails on main at 0.1.6 and passes only with a version ahead of the published revision.
- Mutations applied: n/a — a config-only diff has no mutable code; any mutation of the line (e.g. back to 0.1.6) reproduces the exact release-lane failure quoted above.
- Oracle: Soldeer's published-revision registry — rain-extrospection is published at 0.1.6 (2026-08-18), so the next unpublished version rainix-autopublish accepts is 0.1.7.
- Category check: https://github.com/rainlanguage/rain.extrospection/issues/46 asks for the release lane to publish cleanly post-split; this covers exactly that checkbox — Refs, not Closes, because the remaining checkboxes of the issue are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
