### PR TITLE
Bump rain-solmem 0.1.3 -> 0.1.26

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -24,7 +24,7 @@ runs = 2048
 
 [dependencies]
 forge-std = "1.16.1"
-"rain-solmem" = "0.1.3"
+"rain-solmem" = "0.1.26"
 "rain-math-binary" = "0.1.4"
 
 [soldeer]

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -14,7 +14,7 @@ integrity = "857d22060d058ec173e88448c2d44f0cb884b2381669d0dbe1d3bebb168715ea"
 
 [[dependencies]]
 name = "rain-solmem"
-version = "0.1.3"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-solmem/0_1_3_09-05-2026_19:49:33_rain.zip"
-checksum = "1d405bb81f7c9e56d1717de0d60da918d2fc2fa4db083efd2abe9906378d019f"
-integrity = "e879d2743f9d884f647b9dd489889a83f2cea5f76eb69409a113e1baa69d3643"
+version = "0.1.26"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-solmem/0_1_26_18-08-2026_16:20:17_rain.zip"
+checksum = "291a0acf805b8acd65dfb9e848e6670bde158120bb5b0bcdeeaf17c4084a134c"
+integrity = "54e56c1b10d05df72c1c3dcc8df92b99b9f01cd946363158b077c779ce4d20fa"

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {LibBytes, Pointer} from "rain-solmem-0.1.3/src/lib/LibBytes.sol";
+import {LibBytes, Pointer} from "rain-solmem-0.1.26/src/lib/LibBytes.sol";
 import {EVM_OP_JUMPDEST, HALTING_BITMAP} from "./EVMOpcodes.sol";
 
 /// @dev Byte length of the standard Solidity CBOR metadata trailer that

--- a/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibBytes} from "rain-solmem-0.1.3/src/lib/LibBytes.sol";
+import {LibBytes} from "rain-solmem-0.1.26/src/lib/LibBytes.sol";
 import {LibExtrospectBytecode} from "src/lib/LibExtrospectBytecode.sol";
 import {
     EVM_OP_STOP,


### PR DESCRIPTION
Puts extrospection on the latest solmem, per request.

- `foundry.toml`: rain-solmem 0.1.3 -> 0.1.26
- The two version-pinned `LibBytes` import paths updated to match
- `soldeer.lock` regenerated via `forge soldeer update`

Only `LibBytes.dataPointer()` is consumed and its API is unchanged between the versions (recent solmem changes are NatSpec plus a new truncation error). Local run: 362 passed, 0 failed; the 3 fork tests need RPC env vars and are exercised in CI.

## QA
- Discriminating tests: n/a - dependency version bump with no first-party logic change; the discriminator is the existing 362-test suite passing against the new dependency (verified locally, fork tests excepted for missing RPC env)
- Mutations applied: n/a - no first-party source logic changed; the only source edits are the two version-pinned import path strings, whose mutation is a compile error by construction
- Oracle: the existing test suite, whose expected values predate this change and are independent of the bumped dependency; solmem 0.1.3->0.1.26 diff reviewed for LibBytes API stability (NatSpec + new truncation error only)
- Category check: direct request ("put extrospection on latest solmem"), no issue; covered: dependency pin, import paths, lockfile - the full surface a soldeer bump touches in this org's version-pinned-import convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying memory utility dependency to version 0.1.26.
  * Updated related integrations and validation coverage to use the newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->