### PR TITLE
Reject codeless accounts in address-taking absence checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ with `MetadataNotTrimmed` when there was no metadata trailer to trim at all,
 before any hash comparison happens.
 
 `checkNoSolidityCBORMetadata(account)` is the inverse: it reverts when metadata
-is detected at all, for bytecode that was compiled with metadata disabled.
+is detected at all, for bytecode that was compiled with metadata disabled. It
+also reverts with `CodelessAccount` when the account has no code at all: no
+absence check answers "no code" as a pass, because a codeless account can gain
+any code later.
 
 `isEOFBytecode` and `checkNotEOFBytecode` report and enforce that bytecode is
 not EOF formatted.
@@ -121,6 +124,14 @@ needs storage access that a runtime contract context does not have.
 against `METAMORPHIC_OPS` and returns the risky opcodes that are reachable.
 `checkNotMetamorphic` reverts with `Metamorphic(riskyOpcodes)` when that result
 is non-zero.
+
+Both functions also have address-taking entry points that read the account's
+code, revert with `CodelessAccount` when there is none, and delegate to the
+bytes functions otherwise. An account with no code is the maximally metamorphic
+state — an unoccupied `CREATE2` target, a self-destructed account between
+incarnations, or an EOA that can gain code by EIP-7702 delegation — so only the
+address boundary has the information to refuse to vouch for it. The bytes entry
+points stay total over bytes and answer only about the bytes given.
 
 One fundamental hard requirement of an interpreter is that it is NOT mutable.
 Most obviously this includes `SELFDESTRUCT` as that would allow for things like

--- a/src/interface/IExtrospectV1.sol
+++ b/src/interface/IExtrospectV1.sol
@@ -9,8 +9,8 @@ pragma solidity ^0.8.25;
 /// rain.extrospection.deploy.
 /// @dev The custom errors named below are declared by the libraries, not by
 /// this interface. `EOFBytecodeNotSupported`, `MetadataNotTrimmed`,
-/// `BytecodeHashMismatch` and `UnexpectedMetadata` come from
-/// `LibExtrospectBytecode`; `Metamorphic` comes from
+/// `BytecodeHashMismatch`, `UnexpectedMetadata` and `CodelessAccount` come
+/// from `LibExtrospectBytecode`; `Metamorphic` comes from
 /// `LibExtrospectMetamorphic`.
 interface IExtrospectV1 {
     /// @notice Reads `account`'s runtime bytecode, trims trailing Solidity CBOR
@@ -33,9 +33,11 @@ interface IExtrospectV1 {
     /// @notice Reads `account`'s runtime bytecode and reverts
     /// `UnexpectedMetadata` when its last 53 bytes are the exact Solidity CBOR
     /// metadata structure `tryTrimSolidityCBORMetadata` recognises. Reverts
-    /// `EOFBytecodeNotSupported` when `account`'s bytecode is EOF. Returns
-    /// nothing when no such metadata is detected, including an account with no
-    /// code, and metadata in any other shape.
+    /// `CodelessAccount(account)` when `account` has no code: absence of code
+    /// is not absence of metadata risk, so the check refuses to vouch for a
+    /// codeless account. Reverts `EOFBytecodeNotSupported` when `account`'s
+    /// bytecode is EOF. Returns nothing when the account has code in which no
+    /// such metadata is detected, including metadata in any other shape.
     /// @dev See `LibExtrospectBytecode.checkNoSolidityCBORMetadata`.
     /// @param account The account whose runtime bytecode is read and checked.
     function checkNoSolidityCBORMetadata(address account) external view;

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -77,9 +77,12 @@ library LibExtrospectBytecode {
     /// `0xEF00`. The version byte that follows the magic in an EIP-3540
     /// container is not read, so `0xEF00` alone and `0xEF00` followed by any
     /// version byte are both reported as EOF. Bytecode shorter than two bytes
-    /// is not reported as EOF, and neither is bytecode starting with `0xEF`
-    /// followed by any byte other than `0x00`, including the `0xEF01` of an
-    /// EIP-7702 delegation designator.
+    /// is not reported as EOF — explicitly including empty bytecode, such as
+    /// the code of an account that has none — and neither is bytecode starting
+    /// with `0xEF` followed by any byte other than `0x00`, including the
+    /// `0xEF01` of an EIP-7702 delegation designator. A `false` result says
+    /// the bytes are not an EOF container; over empty bytes it says nothing
+    /// about what code a codeless account may later gain.
     /// @param bytecode The bytecode to check.
     /// @return isEOF Whether the first two bytes are `0xEF00`.
     function isEOFBytecode(bytes memory bytecode) internal pure returns (bool isEOF) {
@@ -242,10 +245,18 @@ library LibExtrospectBytecode {
     /// plus three bytes. Returning without reverting therefore establishes that
     /// this one layout is absent, not that the account carries no metadata.
     ///
+    /// NOTE an account with no code reverts with `CodelessAccount` carrying
+    /// the address, before metadata detection is attempted. Absence of code
+    /// is not absence of metadata risk: a codeless account can gain any code
+    /// later, so this check refuses to vouch for it.
+    ///
     /// @param account The account whose bytecode to check.
     //forge-lint: disable-next-line(mixed-case-function)
     function checkNoSolidityCBORMetadata(address account) internal view {
         bytes memory bytecode = account.code;
+        if (bytecode.length == 0) {
+            revert CodelessAccount(account);
+        }
         bool didTrim = tryTrimSolidityCBORMetadata(bytecode);
         if (didTrim) {
             revert UnexpectedMetadata();
@@ -272,6 +283,10 @@ library LibExtrospectBytecode {
     /// Adapted from https://github.com/MrLuit/selfdestruct-detect/blob/master/src/index.ts
     /// NOTE: Reverts with `EOFBytecodeNotSupported` if the bytecode is EOF
     /// (EIP-7692).
+    /// NOTE: Empty bytecode scans to a zero bitmap: there are no bytes, so no
+    /// opcode is reachable. The empty code of a codeless account scans the
+    /// same way, and zero says nothing about what opcodes that account may
+    /// later gain.
     /// @param bytecode The bytecode to scan.
     /// @return bytesReachable A `uint256` where each bit represents the presence
     /// of a reachable opcode in the source bytecode.
@@ -330,6 +345,10 @@ library LibExtrospectBytecode {
     /// https://github.com/a16z/metamorphic-contract-detector/blob/main/metamorphic_detect/opcodes.py#L52
     /// NOTE: Reverts with `EOFBytecodeNotSupported` if the bytecode is EOF
     /// (EIP-7692).
+    /// NOTE: Empty bytecode scans to a zero bitmap: there are no bytes, so no
+    /// opcode is present. The empty code of a codeless account scans the same
+    /// way, and zero says nothing about what opcodes that account may later
+    /// gain.
     /// @param bytecode The bytecode to scan.
     /// @return bytesPresent A `uint256` where each bit represents the presence
     /// of an opcode in the source bytecode.

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -64,6 +64,15 @@ library LibExtrospectBytecode {
     /// `tryTrimSolidityCBORMetadata` matches.
     error UnexpectedMetadata();
 
+    /// Thrown when an address-taking absence check is asked about an account
+    /// that has no code. An account with no code can gain any code later — an
+    /// unoccupied `CREATE2` target, a self-destructed account between
+    /// incarnations, or an EOA that can gain code by EIP-7702 delegation — so
+    /// absence of code proves nothing and no absence check answers "no code"
+    /// as a pass.
+    /// @param account The account that has no code.
+    error CodelessAccount(address account);
+
     /// Returns whether the first two bytes of the bytecode are the EOF magic
     /// `0xEF00`. The version byte that follows the magic in an EIP-3540
     /// container is not read, so `0xEF00` alone and `0xEF00` followed by any

--- a/src/lib/LibExtrospectERC1167Proxy.sol
+++ b/src/lib/LibExtrospectERC1167Proxy.sol
@@ -65,6 +65,12 @@ library LibExtrospectERC1167Proxy {
     /// A `false` result says that the bytecode is not the canonical minimal
     /// proxy. It does not say that the account runs its own code.
     ///
+    /// Empty bytecode is not 45 bytes long, so it returns
+    /// `(false, address(0))` like every other length mismatch — explicitly
+    /// including the empty code of a codeless account, for which `false`
+    /// says only that no proxy code is present now, not that the account can
+    /// never gain any.
+    ///
     /// The verdict is a function of the 45 bytes alone. It is the same whether
     /// or not the implementation account exists or has code.
     ///

--- a/src/lib/LibExtrospectMetamorphic.sol
+++ b/src/lib/LibExtrospectMetamorphic.sol
@@ -7,7 +7,10 @@ import {METAMORPHIC_OPS} from "./EVMOpcodes.sol";
 
 /// @title LibExtrospectMetamorphic
 /// @notice Detection and guarding against metamorphic contract risk. Scans
-/// bytecode for reachable opcodes in `METAMORPHIC_OPS`.
+/// bytecode for reachable opcodes in `METAMORPHIC_OPS`. The bytes-taking
+/// entry points are total over bytes and answer only about the bytes given;
+/// the address-taking entry points bind the verdict to an account and revert
+/// with `CodelessAccount` rather than vouch for an account that has no code.
 library LibExtrospectMetamorphic {
     /// Thrown when metamorphic risk opcodes are reachable in bytecode.
     /// @param riskyOpcodes Bitmap of reachable metamorphic opcodes.
@@ -15,6 +18,8 @@ library LibExtrospectMetamorphic {
 
     /// Scans bytecode for reachable metamorphic risk opcodes. Reverts with
     /// `EOFBytecodeNotSupported` if the bytecode is EOF.
+    /// Answers only about the bytes given. Use `scanMetamorphicRisk(address)`
+    /// to bind the scan to an account and reject a codeless one.
     /// @param bytecode The bytecode to scan.
     /// @return riskyOpcodes Bitmap of reachable metamorphic opcodes. Zero if
     /// no metamorphic risk opcodes are reachable, including when `bytecode` is
@@ -30,6 +35,8 @@ library LibExtrospectMetamorphic {
     /// `CREATE2` target, or a self-destructed account — passes this check on
     /// the same terms as an account whose code has no reachable metamorphic
     /// opcodes. Whether the account has any code at all is not checked here.
+    /// Use `checkNotMetamorphic(address)` to bind the verdict to an account
+    /// and reject a codeless one.
     /// @param bytecode The bytecode to check.
     function checkNotMetamorphic(bytes memory bytecode) internal pure {
         uint256 riskyOpcodes = scanMetamorphicRisk(bytecode);
@@ -39,18 +46,33 @@ library LibExtrospectMetamorphic {
     }
 
     /// Reads `account`'s code and scans it for reachable metamorphic risk
-    /// opcodes, delegating to `scanMetamorphicRisk(bytes)`.
+    /// opcodes, delegating to `scanMetamorphicRisk(bytes)`. Reverts with
+    /// `CodelessAccount` carrying the address when the account has no code:
+    /// an account with no code is the maximally metamorphic state — an
+    /// unoccupied `CREATE2` target, a self-destructed account between
+    /// incarnations, or an EOA that can gain code by EIP-7702 delegation —
+    /// and the chain cannot distinguish "can never gain code" from "can gain
+    /// anything", so a zero bitmap for it would vouch for nothing. Reverts
+    /// with `EOFBytecodeNotSupported` if the account's code is EOF, as the
+    /// bytes scan does.
     /// @param account The account whose code to scan.
     /// @return riskyOpcodes Bitmap of reachable metamorphic opcodes in the
     /// account's code. Zero if none are reachable.
     function scanMetamorphicRisk(address account) internal view returns (uint256 riskyOpcodes) {
         bytes memory bytecode = account.code;
+        if (bytecode.length == 0) {
+            revert LibExtrospectBytecode.CodelessAccount(account);
+        }
         riskyOpcodes = scanMetamorphicRisk(bytecode);
     }
 
     /// Reads `account`'s code and reverts with `Metamorphic` if any
     /// metamorphic risk opcodes are reachable in it, delegating to
-    /// `scanMetamorphicRisk(address)`.
+    /// `scanMetamorphicRisk(address)`. Reverts with `CodelessAccount`
+    /// carrying the address when the account has no code, on the same terms
+    /// as `scanMetamorphicRisk(address)`: no absence check answers "no code"
+    /// as a pass. Reverts with `EOFBytecodeNotSupported` if the account's
+    /// code is EOF.
     /// @param account The account whose code to check.
     function checkNotMetamorphic(address account) internal view {
         uint256 riskyOpcodes = scanMetamorphicRisk(account);

--- a/src/lib/LibExtrospectMetamorphic.sol
+++ b/src/lib/LibExtrospectMetamorphic.sol
@@ -58,12 +58,12 @@ library LibExtrospectMetamorphic {
     /// @param account The account whose code to scan.
     /// @return riskyOpcodes Bitmap of reachable metamorphic opcodes in the
     /// account's code. Zero if none are reachable.
-    function scanMetamorphicRisk(address account) internal view returns (uint256 riskyOpcodes) {
+    function scanMetamorphicRisk(address account) internal view returns (uint256) {
         bytes memory bytecode = account.code;
         if (bytecode.length == 0) {
             revert LibExtrospectBytecode.CodelessAccount(account);
         }
-        riskyOpcodes = scanMetamorphicRisk(bytecode);
+        return scanMetamorphicRisk(bytecode);
     }
 
     /// Reads `account`'s code and reverts with `Metamorphic` if any

--- a/src/lib/LibExtrospectMetamorphic.sol
+++ b/src/lib/LibExtrospectMetamorphic.sol
@@ -37,4 +37,25 @@ library LibExtrospectMetamorphic {
             revert Metamorphic(riskyOpcodes);
         }
     }
+
+    /// Reads `account`'s code and scans it for reachable metamorphic risk
+    /// opcodes, delegating to `scanMetamorphicRisk(bytes)`.
+    /// @param account The account whose code to scan.
+    /// @return riskyOpcodes Bitmap of reachable metamorphic opcodes in the
+    /// account's code. Zero if none are reachable.
+    function scanMetamorphicRisk(address account) internal view returns (uint256 riskyOpcodes) {
+        bytes memory bytecode = account.code;
+        riskyOpcodes = scanMetamorphicRisk(bytecode);
+    }
+
+    /// Reads `account`'s code and reverts with `Metamorphic` if any
+    /// metamorphic risk opcodes are reachable in it, delegating to
+    /// `scanMetamorphicRisk(address)`.
+    /// @param account The account whose code to check.
+    function checkNotMetamorphic(address account) internal view {
+        uint256 riskyOpcodes = scanMetamorphicRisk(account);
+        if (riskyOpcodes != 0) {
+            revert Metamorphic(riskyOpcodes);
+        }
+    }
 }

--- a/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.checkNoSolidityCBORMetadata.t.sol
@@ -50,9 +50,14 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
         offsets = [uint256(0), 1, 2, 3, 4, 5, 6, 7, 42, 43, 44, 45, 46, 47, 51, 52];
     }
 
-    /// Account with no code passes (no metadata to detect).
-    function testCheckNoMetadataEmptyAccount() external view {
-        LibExtrospectBytecode.checkNoSolidityCBORMetadata(address(0xdead));
+    /// Account with no code reverts with `CodelessAccount` carrying the
+    /// address. An account with no code can gain any code later, so the
+    /// absence check refuses to vouch for it instead of passing it.
+    function testCheckNoMetadataRevertsOnCodelessAccount() external {
+        address codeless = address(0xdead);
+        assertEq(codeless.code.length, 0);
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.CodelessAccount.selector, codeless));
+        this.checkNoSolidityCBORMetadataExternal(codeless);
     }
 
     /// Contract compiled without metadata passes. This project compiles with
@@ -81,9 +86,12 @@ contract LibExtrospectBytecodeCheckNoSolidityCBORMetadataTest is Test {
         this.checkNoSolidityCBORMetadataExternal(target);
     }
 
-    /// Fuzz: bytecode shorter than Solidity CBOR metadata passes. The
-    /// leading `STOP` keeps the bytecode out of the EOF format.
+    /// Fuzz: nonempty bytecode shorter than Solidity CBOR metadata passes.
+    /// The leading `STOP` keeps the bytecode out of the EOF format. Empty
+    /// bytecode is excluded: an account etched with empty code is codeless
+    /// and reverts with `CodelessAccount`, pinned deterministically above.
     function testCheckNoMetadataPassesShortBytecode(bytes memory code) external {
+        vm.assume(code.length > 0);
         uint256 length = code.length;
         if (length >= SOLIDITY_CBOR_METADATA_LENGTH) {
             length = SOLIDITY_CBOR_METADATA_LENGTH - 1;

--- a/test/src/lib/LibExtrospectBytecode.isEOFBytecode.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.isEOFBytecode.t.sol
@@ -18,6 +18,15 @@ contract LibExtrospectBytecodeIsEOFBytecodeTest is Test {
         assertFalse(LibExtrospectBytecode.isEOFBytecode(hex""));
     }
 
+    /// The empty code of a codeless account is not EOF. Pins the documented
+    /// empty-input meaning at the account reading: `false` here says the
+    /// bytes are not an EOF container, not that the account has code.
+    function testIsEOFBytecodeCodelessAccount() external view {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        assertFalse(LibExtrospectBytecode.isEOFBytecode(codeless.code));
+    }
+
     /// Test that a single bytecode is not EOF.
     function testIsEOFBytecodeSingleByte() external pure {
         assertFalse(LibExtrospectBytecode.isEOFBytecode(hex"EF"));

--- a/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode.t.sol
@@ -155,6 +155,15 @@ contract LibExtrospectBytecodeScanEVMOpcodesPresentInBytecodeTest is Test {
         assertEq(LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(hex""), 0);
     }
 
+    /// The empty code of a codeless account scans to a zero bitmap. Pins the
+    /// documented empty-input meaning at the account reading: zero here says
+    /// no opcodes were read, not that the account can never gain any.
+    function testScanEVMOpcodesPresentCodelessAccount() public view {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        assertEq(LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(codeless.code), 0);
+    }
+
     /// Test single-byte non-PUSH bytecodes.
     function testScanEVMOpcodesPresentSingleByte() public pure {
         // STOP

--- a/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
@@ -162,6 +162,16 @@ contract LibExtrospectScanEVMOpcodesReachableInBytecodeTest is Test {
         assertEq(LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(hex""), 0);
     }
 
+    /// The empty code of a codeless account scans to a zero bitmap. Pins the
+    /// documented empty-input meaning at the account reading: zero here says
+    /// no opcodes were scanned as reachable, not that the account can never
+    /// gain any.
+    function testScanEVMOpcodesReachableCodelessAccount() public view {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        assertEq(LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(codeless.code), 0);
+    }
+
     /// Test truncated PUSH1 at end of bytecode (no data byte following).
     function testScanEVMOpcodesReachableTruncatedPush1() public pure {
         assertEq(LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(hex"60"), 1 << 0x60);

--- a/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
+++ b/test/src/lib/LibExtrospectERC1167Proxy.isERC1167Proxy.t.sol
@@ -163,6 +163,26 @@ contract LibExtrospectERC1167ProxyTest is Test {
         assertEq(implementationResult, implementation);
     }
 
+    /// Empty bytecode is not the 45 byte proxy: `(false, address(0))`. Pins
+    /// the documented empty-input meaning.
+    function testIsERC1167ProxyEmpty() external pure {
+        (bool result, address implementationAddress) = LibExtrospectERC1167Proxy.isERC1167Proxy(hex"");
+        assertFalse(result);
+        assertEq(implementationAddress, address(0));
+    }
+
+    /// The empty code of a codeless account is not the 45 byte proxy. Pins
+    /// the documented empty-input meaning at the account reading: `false`
+    /// here says the bytes are not the canonical minimal proxy, not that the
+    /// account runs its own code or has any code at all.
+    function testIsERC1167ProxyCodelessAccount() external view {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        (bool result, address implementationAddress) = LibExtrospectERC1167Proxy.isERC1167Proxy(codeless.code);
+        assertFalse(result);
+        assertEq(implementationAddress, address(0));
+    }
+
     /// A 45-byte clone encoding `address(0)` as the implementation is detected
     /// as a proxy, so `(true, address(0))` is a reachable return value and the
     /// returned address alone does not distinguish a proxy from a non-proxy.

--- a/test/src/lib/LibExtrospectMetamorphic.checkNotMetamorphic.t.sol
+++ b/test/src/lib/LibExtrospectMetamorphic.checkNotMetamorphic.t.sol
@@ -15,11 +15,17 @@ import {HasCreate} from "test/concrete/HasCreate.sol";
 import {NonMetamorphic} from "test/concrete/NonMetamorphic.sol";
 import {CreateChildFactory} from "test/concrete/CreateChildFactory.sol";
 import {Create2ChildFactory} from "test/concrete/Create2ChildFactory.sol";
+import {LibExtrospectTestEtch} from "test/lib/LibExtrospectTestEtch.sol";
 
 contract LibExtrospectMetamorphicCheckNotMetamorphicTest is Test {
     /// External wrapper for revert tests.
     function checkNotMetamorphicExternal(bytes memory bytecode) external pure {
         LibExtrospectMetamorphic.checkNotMetamorphic(bytecode);
+    }
+
+    /// External wrapper for address entry point revert tests.
+    function checkNotMetamorphicAddressExternal(address account) external view {
+        LibExtrospectMetamorphic.checkNotMetamorphic(account);
     }
 
     /// Clean contract passes.
@@ -120,6 +126,57 @@ contract LibExtrospectMetamorphicCheckNotMetamorphicTest is Test {
     function testCheckNotMetamorphicRevertsOnEOF() external {
         vm.expectRevert(LibExtrospectBytecode.EOFBytecodeNotSupported.selector);
         this.checkNotMetamorphicExternal(hex"EF00010203");
+    }
+
+    /// Address entry point: a codeless account reverts with `CodelessAccount`
+    /// carrying the address. The bytes entry point passes the same account's
+    /// (empty) code, pinned by `testCheckNotMetamorphicCodelessAccount`; only
+    /// the address boundary can refuse to vouch for a codeless account.
+    function testCheckNotMetamorphicAddressRevertsOnCodelessAccount() external {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.CodelessAccount.selector, codeless));
+        this.checkNotMetamorphicAddressExternal(codeless);
+    }
+
+    /// Address entry point: clean contract passes.
+    function testCheckNotMetamorphicAddressClean() external {
+        NonMetamorphic clean = new NonMetamorphic();
+        LibExtrospectMetamorphic.checkNotMetamorphic(address(clean));
+    }
+
+    /// Address entry point: contract with SELFDESTRUCT reverts with the same
+    /// `Metamorphic` error as the bytes entry point.
+    function testCheckNotMetamorphicAddressRevertsOnSelfdestruct() external {
+        HasSelfdestruct c = new HasSelfdestruct();
+        uint256 risk = LibExtrospectMetamorphic.scanMetamorphicRisk(address(c).code);
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectMetamorphic.Metamorphic.selector, risk));
+        this.checkNotMetamorphicAddressExternal(address(c));
+    }
+
+    /// Address entry point: EOF code etched onto an account reverts with
+    /// `EOFBytecodeNotSupported` via delegation to the bytes entry point.
+    function testCheckNotMetamorphicAddressRevertsOnEOF() external {
+        address target = address(0xBEEF);
+        vm.etch(target, hex"EF00010203");
+        vm.expectRevert(LibExtrospectBytecode.EOFBytecodeNotSupported.selector);
+        this.checkNotMetamorphicAddressExternal(target);
+    }
+
+    /// Fuzz: for an account with nonempty non-EOF code, the address entry
+    /// point and the bytes entry point agree: both revert with the same
+    /// `Metamorphic` bitmap or both pass.
+    function testCheckNotMetamorphicAddressEquivalenceFuzz(bytes memory code) external {
+        vm.assume(code.length > 0);
+        vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
+        address target = address(0xBEEF);
+        LibExtrospectTestEtch.assumeEtch(vm, target, code);
+
+        uint256 risk = LibExtrospectMetamorphic.scanMetamorphicRisk(code);
+        if (risk != 0) {
+            vm.expectRevert(abi.encodeWithSelector(LibExtrospectMetamorphic.Metamorphic.selector, risk));
+        }
+        this.checkNotMetamorphicAddressExternal(target);
     }
 
     /// Fuzz: checkNotMetamorphic reverts iff scanMetamorphicRisk is non-zero.

--- a/test/src/lib/LibExtrospectMetamorphic.scanMetamorphicRisk.t.sol
+++ b/test/src/lib/LibExtrospectMetamorphic.scanMetamorphicRisk.t.sol
@@ -23,11 +23,67 @@ import {CreateChildFactory} from "test/concrete/CreateChildFactory.sol";
 import {Create2ChildFactory} from "test/concrete/Create2ChildFactory.sol";
 import {ChildLeaf} from "test/concrete/ChildLeaf.sol";
 import {NonMetamorphic} from "test/concrete/NonMetamorphic.sol";
+import {LibExtrospectTestEtch} from "test/lib/LibExtrospectTestEtch.sol";
 
 contract LibExtrospectMetamorphicScanMetamorphicRiskTest is Test {
     /// External wrapper for EOF revert test.
     function scanMetamorphicRiskExternal(bytes memory bytecode) external pure returns (uint256) {
         return LibExtrospectMetamorphic.scanMetamorphicRisk(bytecode);
+    }
+
+    /// External wrapper for address entry point revert tests.
+    function scanMetamorphicRiskAddressExternal(address account) external view returns (uint256) {
+        return LibExtrospectMetamorphic.scanMetamorphicRisk(account);
+    }
+
+    /// Address entry point: a codeless account reverts with `CodelessAccount`
+    /// carrying the address. The bytes entry point returns zero for the same
+    /// account's (empty) code, pinned by
+    /// `testScanMetamorphicRiskCodelessAccount`; only the address boundary can
+    /// refuse to vouch for a codeless account.
+    function testScanMetamorphicRiskAddressRevertsOnCodelessAccount() external {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.CodelessAccount.selector, codeless));
+        this.scanMetamorphicRiskAddressExternal(codeless);
+    }
+
+    /// Address entry point: clean contract scans to zero.
+    function testScanMetamorphicRiskAddressClean() external {
+        NonMetamorphic clean = new NonMetamorphic();
+        assertEq(LibExtrospectMetamorphic.scanMetamorphicRisk(address(clean)), 0);
+    }
+
+    /// Address entry point: contract with SELFDESTRUCT scans with the
+    /// SELFDESTRUCT bit set, same as the bytes entry point over its code.
+    function testScanMetamorphicRiskAddressSelfdestruct() external {
+        HasSelfdestruct c = new HasSelfdestruct();
+        uint256 risk = LibExtrospectMetamorphic.scanMetamorphicRisk(address(c));
+        //forge-lint: disable-next-line(incorrect-shift)
+        assertTrue(risk & (1 << uint256(EVM_OP_SELFDESTRUCT)) != 0);
+        assertEq(risk, LibExtrospectMetamorphic.scanMetamorphicRisk(address(c).code));
+    }
+
+    /// Address entry point: EOF code etched onto an account reverts with
+    /// `EOFBytecodeNotSupported` via delegation to the bytes entry point.
+    function testScanMetamorphicRiskAddressRevertsOnEOF() external {
+        address target = address(0xBEEF);
+        vm.etch(target, hex"EF00010203");
+        vm.expectRevert(LibExtrospectBytecode.EOFBytecodeNotSupported.selector);
+        this.scanMetamorphicRiskAddressExternal(target);
+    }
+
+    /// Fuzz: for an account with nonempty non-EOF code, the address entry
+    /// point returns exactly what the bytes entry point returns for that code.
+    function testScanMetamorphicRiskAddressEquivalenceFuzz(bytes memory code) external {
+        vm.assume(code.length > 0);
+        vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
+        address target = address(0xBEEF);
+        LibExtrospectTestEtch.assumeEtch(vm, target, code);
+
+        assertEq(
+            LibExtrospectMetamorphic.scanMetamorphicRisk(target), LibExtrospectMetamorphic.scanMetamorphicRisk(code)
+        );
     }
 
     /// Empty bytecode has no metamorphic risk.


### PR DESCRIPTION
Closes #132

Implements ruling E+D on #55 exactly as #132 scopes it: no absence check may answer "no code" as a pass. An empty account is the maximally metamorphic state — an unoccupied `CREATE2` target, a self-destructed account between incarnations, an EOA that can gain code by EIP-7702 delegation — and the chain cannot distinguish "can never gain code" from "can gain anything", so only the address boundary has the information to refuse to vouch for it.

## What changed

- **`LibExtrospectBytecode.checkNoSolidityCBORMetadata(address)`** gains the `code.length == 0` guard and reverts with the new `CodelessAccount(address)` error carrying the address. No new API for this function.
- **`LibExtrospectMetamorphic`** gains the address-taking entry points `scanMetamorphicRisk(address)` and `checkNotMetamorphic(address)`: both revert `CodelessAccount(account)` on a codeless account, then delegate to the bytes functions. This is the metamorphic half of #83; the opcode-scan half of #83 stays open.
- **Bytes-taking functions stay total over bytes.** `scanMetamorphicRisk(bytes)` / `checkNotMetamorphic(bytes)` keep the behaviour documented and pinned in #96; their NatSpec now cross-references the address entry points as the way to bind a verdict to an account.
- **Non-reverting predicates** (`isEOFBytecode`, `isERC1167Proxy`, `scanEVMOpcodesPresentInBytecode`, `scanEVMOpcodesReachableInBytecode`) now state their empty-input meaning explicitly in NatSpec, pinned by deterministic tests at both the empty-literal and codeless-account (`codeless.code`) readings.
- **`IExtrospectV1`** NatSpec updated: `checkNoSolidityCBORMetadata` no longer documents "returns nothing ... including an account with no code" — it documents the `CodelessAccount` revert — and the error roster gains `CodelessAccount`. No function was added to or removed from the interface.
- **README** updated for both behaviours.

Out of scope, untouched: #54 (EIP-7702 designator vs the metamorphic scan is a separate bytes-level defect; `isEOFBytecode` matching is unchanged).

## TDD

Failing-tests commit d91665a adds the discriminating tests plus the minimal scaffold they need to compile (`CodelessAccount` declared, address entry points present deliberately WITHOUT the guard). `nix develop -c forge test`: **374 passed, 6 failed** — the 3 new codeless tests failing "next call did not revert as expected", plus the 3 fork tests needing `ARBITRUM_RPC_URL` (environmental, identical on main).

Implementation commit aaa05ea adds the guards and docs. `nix develop -c forge test`: **377 passed, 3 failed** — only the environmental fork tests.

## QA

- Discriminating tests:
  - `testCheckNoMetadataRevertsOnCodelessAccount` — codeless account reverts `CodelessAccount(0xdead)` from `checkNoSolidityCBORMetadata` (flips the previous `testCheckNoMetadataEmptyAccount`, which pinned the pass).
  - `testScanMetamorphicRiskAddressRevertsOnCodelessAccount`, `testCheckNotMetamorphicAddressRevertsOnCodelessAccount` — codeless account reverts `CodelessAccount(0xC2)` from both address entry points, while the bytes entry points still pass the same account's empty code (`testScanMetamorphicRiskCodelessAccount`, `testCheckNotMetamorphicCodelessAccount`, unchanged from #96).
  - Address entry point delegation: `testScanMetamorphicRiskAddressClean` / `testCheckNotMetamorphicAddressClean` (pass), `testScanMetamorphicRiskAddressSelfdestruct` / `testCheckNotMetamorphicAddressRevertsOnSelfdestruct` (risk bit / `Metamorphic` revert), `test*AddressRevertsOnEOF` (`EOFBytecodeNotSupported` through the delegate), and `test*AddressEquivalenceFuzz` (address vs bytes agreement over nonempty non-EOF etched code).
  - Empty-input pinning: `testIsEOFBytecodeCodelessAccount`, `testIsERC1167ProxyEmpty`, `testIsERC1167ProxyCodelessAccount`, `testScanEVMOpcodesPresentCodelessAccount`, `testScanEVMOpcodesReachableCodelessAccount` (new, deterministic), alongside the pre-existing empty-literal tests.
- Mutations applied (each applied to the working tree, `nix develop -c forge test --no-match-path "*fork*"` run in full, then reverted; baseline for that command is 377 passed, 0 failed):
  | # | Mutant (applied to `src`, then reverted) | Outcome |
  |---|---|---|
  | M1 | `checkNoSolidityCBORMetadata`: codeless guard deleted | KILLED: `testCheckNoMetadataRevertsOnCodelessAccount` ("next call did not revert as expected"); 376 passed, 1 failed |
  | M2 | codeless guard reverts `CodelessAccount(address(0))` instead of the account | KILLED: same test, revert-data mismatch `CodelessAccount(0x0000...0000) != CodelessAccount(0x0...dEaD)` — the error's address payload is pinned; 376 passed, 1 failed |
  | M3 | `scanMetamorphicRisk(address)`: codeless guard deleted | KILLED: `testScanMetamorphicRiskAddressRevertsOnCodelessAccount` and `testCheckNotMetamorphicAddressRevertsOnCodelessAccount` (the check inherits the scan's guard); 375 passed, 2 failed |
  | M4 | `scanMetamorphicRisk(address)`: delegation dropped (`riskyOpcodes = 0`) | KILLED: 6 tests — `testScanMetamorphicRiskAddressSelfdestruct`, `testCheckNotMetamorphicAddressRevertsOnSelfdestruct`, both `*AddressRevertsOnEOF` tests, both `*AddressEquivalenceFuzz` tests; 371 passed, 6 failed |
  | M5 | `checkNotMetamorphic(address)`: `Metamorphic` revert made unreachable (`riskyOpcodes != riskyOpcodes`) | KILLED: `testCheckNotMetamorphicAddressRevertsOnSelfdestruct` and `testCheckNotMetamorphicAddressEquivalenceFuzz`; 375 passed, 2 failed |
  | M6 | guard boundary `bytecode.length == 0` -> `== 1` | KILLED: both `*AddressRevertsOnCodelessAccount` tests (length 0 no longer reverts) and both `*AddressEquivalenceFuzz` tests with a 1-byte-code counterexample (`args=[0xa9]` reverting `CodelessAccount(0xbEEF)`); 373 passed, 4 failed |

  All 6 mutants killed, 0 survivors.
- Oracle: the ruling text on #55 (https://github.com/rainlanguage/rain.extrospection/issues/55#issuecomment-5338743715) as scoped by #132, read independently of the implementation: every address-taking absence check must revert on a codeless account with a typed error carrying the address; bytes functions stay total; non-reverting predicates document their empty-input meaning. Expected revert data in tests is constructed from the ruling's required shape (`CodelessAccount(address)`) via `abi.encodeWithSelector`, not observed from the code under test.
- Category check: #132 asks for (1) the CBOR guard with a typed address-carrying error — covered, `src/lib/LibExtrospectBytecode.sol`; (2) address-taking metamorphic entry points reverting on codeless then delegating — covered, `src/lib/LibExtrospectMetamorphic.sol`; (3) bytes functions total with empty meaning documented and pinned — already done in #96, cross-references added, pins retained; (4) non-reverting predicates' empty-input meaning explicit in NatSpec with deterministic pins — covered, `LibExtrospectBytecode.sol`, `LibExtrospectERC1167Proxy.sol` and the four test files. Nothing outside that scope was changed; #54 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
