### PR TITLE
Pin the reject side of the beacon dirty-bits gate

### DIFF
--- a/test/concrete/DirtyUpperByteBeacon.sol
+++ b/test/concrete/DirtyUpperByteBeacon.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @dev Beacon test fixture whose `implementation()` and `owner()`
+/// selectors exist and return successfully, but with a 32-byte word
+/// holding a real address below a dirty byte: only bits 160-167 are
+/// set above the 160 address bits. A gate widened to any width of
+/// 168 bits or more accepts this word and truncates it to the
+/// embedded address, so both public predicates would then compare an
+/// attacker-chosen address where they must report failure. Pins the
+/// second cell of the reject-side partition, alongside
+/// `OneAboveMaxAddressBeacon`'s exact-boundary `2 ** 160`.
+///
+/// Cannot `is IBeacon, IOwnable` — return types deliberately differ
+/// from the interfaces. That mismatch is the test condition.
+contract DirtyUpperByteBeacon {
+    /// @dev The dirty word both selectors answer with: `addr` with all
+    /// eight of bits 160-167 set above it.
+    uint256 private immutable _dirtyWord;
+
+    constructor(address addr) {
+        _dirtyWord = (uint256(0xFF) << 160) | uint256(uint160(addr));
+    }
+
+    function implementation() external view returns (uint256) {
+        return _dirtyWord;
+    }
+
+    function owner() external view returns (uint256) {
+        return _dirtyWord;
+    }
+}

--- a/test/concrete/OneAboveMaxAddressBeacon.sol
+++ b/test/concrete/OneAboveMaxAddressBeacon.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @dev Beacon test fixture whose `implementation()` and `owner()`
+/// selectors exist and return successfully, but with exactly
+/// `2 ** 160` — the first value the dirty-bits gate
+/// (`raw > type(uint160).max`) must reject. Only bit 160 is set, so
+/// any widening of the gate past 160 bits accepts this word and
+/// truncates it to `address(0)`. Pins the reject side of the boundary
+/// whose accept side `testMatchesAtMaxAddressBoundary` pins with
+/// `2 ** 160 - 1`.
+///
+/// Cannot `is IBeacon, IOwnable` — return types deliberately differ
+/// from the interfaces. That mismatch is the test condition.
+contract OneAboveMaxAddressBeacon {
+    function implementation() external pure returns (uint256) {
+        return uint256(type(uint160).max) + 1;
+    }
+
+    function owner() external pure returns (uint256) {
+        return uint256(type(uint160).max) + 1;
+    }
+}

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode.t.sol
@@ -13,6 +13,8 @@ import {EmptyContract} from "test/concrete/EmptyContract.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
+import {OneAboveMaxAddressBeacon} from "test/concrete/OneAboveMaxAddressBeacon.sol";
+import {DirtyUpperByteBeacon} from "test/concrete/DirtyUpperByteBeacon.sol";
 import {PermissiveFallbackContract} from "test/concrete/PermissiveFallbackContract.sol";
 import {
     RevertingWithAddressBeacon,
@@ -143,6 +145,32 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest is Te
         MockBeacon beacon = new MockBeacon(maxAddr, address(this));
         assertTrue(
             LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256(maxAddr.code))
+        );
+    }
+
+    /// `2 ** 160` is the first value the dirty-bits gate
+    /// (`raw > type(uint160).max`) must reject — the reject side of the
+    /// boundary whose accept side `testMatchesAtMaxAddressBoundary`
+    /// pins. The expected hash is `keccak256("")`: exactly what a gate
+    /// widened past 160 bits would match after truncating `2 ** 160`
+    /// to the codeless `address(0)`.
+    function testReturnsFalseAtOneAboveMaxAddressBoundary() external {
+        OneAboveMaxAddressBeacon beacon = new OneAboveMaxAddressBeacon();
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(address(beacon), keccak256("")));
+    }
+
+    /// A 32-byte return holding a real deployed address with only bits
+    /// 160-167 set above it must be rejected as dirty, not truncated.
+    /// The expected hash is that of the embedded address's runtime
+    /// bytecode: exactly what a gate widened to 168 bits or more would
+    /// match after truncating the word to that address.
+    function testReturnsFalseOnDirtyUpperByteAboveRealAddress() external {
+        EmptyContract impl = new EmptyContract();
+        DirtyUpperByteBeacon beacon = new DirtyUpperByteBeacon(address(impl));
+        assertFalse(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                address(beacon), keccak256(address(impl).code)
+            )
         );
     }
 

--- a/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
+++ b/test/src/lib/LibExtrospectERC1967BeaconProxy.isBeaconOwner.t.sol
@@ -9,6 +9,8 @@ import {EmptyContract} from "test/concrete/EmptyContract.sol";
 import {RevertingBeacon} from "test/concrete/RevertingBeacon.sol";
 import {BogusBeacon} from "test/concrete/BogusBeacon.sol";
 import {WrongLengthBeacon} from "test/concrete/WrongLengthBeacon.sol";
+import {OneAboveMaxAddressBeacon} from "test/concrete/OneAboveMaxAddressBeacon.sol";
+import {DirtyUpperByteBeacon} from "test/concrete/DirtyUpperByteBeacon.sol";
 import {PermissiveFallbackContract} from "test/concrete/PermissiveFallbackContract.sol";
 import {
     RevertingWithAddressBeacon,
@@ -86,6 +88,27 @@ contract LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest is Test {
         address maxAddr = address(type(uint160).max);
         MockBeacon beacon = new MockBeacon(address(this), maxAddr);
         assertTrue(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), maxAddr));
+    }
+
+    /// `2 ** 160` is the first value the dirty-bits gate
+    /// (`raw > type(uint160).max`) must reject — the reject side of the
+    /// boundary whose accept side `testMatchesAtMaxAddressBoundary`
+    /// pins. The expected owner is `address(0)`: exactly what a gate
+    /// widened past 160 bits would truncate `2 ** 160` to and report
+    /// as a match.
+    function testReturnsFalseAtOneAboveMaxAddressBoundary() external {
+        OneAboveMaxAddressBeacon beacon = new OneAboveMaxAddressBeacon();
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), address(0)));
+    }
+
+    /// A 32-byte return holding a real address with only bits 160-167
+    /// set above it must be rejected as dirty, not truncated. The
+    /// expected owner is the embedded address itself: exactly what a
+    /// gate widened to 168 bits or more would truncate the word to and
+    /// report as a match.
+    function testReturnsFalseOnDirtyUpperByteAboveRealAddress(address own) external {
+        DirtyUpperByteBeacon beacon = new DirtyUpperByteBeacon(own);
+        assertFalse(LibExtrospectERC1967BeaconProxy.isBeaconOwner(address(beacon), own));
     }
 
     /// A beacon whose `owner()` returns more than 32 bytes must also


### PR DESCRIPTION
Pins the reject side of the beacon dirty-bits gate
(`raw > type(uint160).max` in
`LibExtrospectERC1967BeaconProxy._tryGetAddress`), per the issue's proposed
fix. The suite pinned the accept side (`2 ** 160 - 1` via
`testMatchesAtMaxAddressBoundary`) but nothing pinned `2 ** 160`, the first
value the gate must reject, so widening the gate past 160 bits shipped green.

Purely additive:

- `test/concrete/OneAboveMaxAddressBeacon.sol` — fixture whose
  `implementation()` and `owner()` return exactly `2 ** 160`; a widened gate
  truncates it to `address(0)`.
- `test/concrete/DirtyUpperByteBeacon.sol` — fixture returning a real address
  with only bits 160-167 set above it; a gate widened to 168 bits or more
  truncates it to the embedded address.
- One test per fixture per public predicate (`isBeaconOwner`,
  `isBeaconImplementationBytecode`), each asserting false against exactly the
  value a truncating gate would report as a match.

No `src/` changes. The issue's masking caveat (default-profile kills being
absorbed by the compiler-output pins of #84) no longer applies: those tests
have left this repo, and the widening mutant now survives the default profile
on main outright — verified below.

## QA

Discriminating tests:

- `LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest.testReturnsFalseAtOneAboveMaxAddressBoundary`
- `LibExtrospectERC1967BeaconProxyIsBeaconOwnerTest.testReturnsFalseOnDirtyUpperByteAboveRealAddress` (fuzz)
- `LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest.testReturnsFalseAtOneAboveMaxAddressBoundary`
- `LibExtrospectERC1967BeaconProxyIsBeaconImplementationBytecodeTest.testReturnsFalseOnDirtyUpperByteAboveRealAddress`

Mutations applied (real edits to
`src/lib/LibExtrospectERC1967BeaconProxy.sol`, default profile, fork file
excluded for missing RPC env):

1. `raw > type(uint160).max` -> `raw > type(uint168).max` (the issue's
   widening mutant). Before this PR's tests: **377 passed, 0 failed —
   SURVIVED**, identical to the clean baseline. With this PR's tests:
   **377 passed, 4 failed — KILLED**, the 4 failures being exactly the 4
   discriminating tests above.
2. `if (ok == 0 || raw > type(uint160).max)` -> `if (ok == 0)` (dirty-bits
   clause deleted). With this PR's tests: **374 passed, 7 failed — KILLED**: all 4 discriminating tests plus 3 existing dirty-address tests (`testReturnsFalseOnInvalidReturnEncoding` fuzz in both suites and `testFalseOnDirtyAddress` in the `beaconImplementation` suite).

Oracle: the function's own `@dev` — 32-byte returndata whose upper 12 bytes
are non-zero is one of the folded failure modes, so the gate is a boundary at
`2 ** 160` and each side needs a pin. Expected values in the new tests are
chosen adversarially: each equals exactly what the truncating mutant would
report as a match, so a false there separates rejection from truncation.

Category check: additive test-only change; no behavior change, no verdict
change. Clean-source run after adding the tests: 381 passed, 0 failed
(fork file excluded; its 3 tests fail locally only on missing
`ARBITRUM_RPC_URL`, which is environmental). `forge fmt --check` clean on all
four touched files.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
