### PR TITLE
Address-taking opcode scans reject codeless accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ opcodes found in the bytecode passed to them. This bitmap is built as
 `1 << opcode` where opcode is a single byte, and the scan is a `uint256` so the
 space of all opcodes as a `uint8` maps perfectly to all the bits in an EVM word.
 
-Both scans take bytecode as `bytes memory` rather than an address, so the caller
-chooses what to feed them: `account.code`, a constructor argument, or bytecode
-already trimmed by `tryTrimSolidityCBORMetadata`.
+Both scans take bytecode as `bytes memory`, so the caller chooses what to feed
+them: `account.code`, a constructor argument, or bytecode already trimmed by
+`tryTrimSolidityCBORMetadata`.
 
 The "present in" scan simply loops over the entire bytecode, but is `PUSH*`
 aware so knows that the inline argument to any `PUSH` opcode is not itself an
@@ -60,6 +60,15 @@ scanner will require an entirely new implementation and redeployment to support
 this.
 
 Both scans revert with `EOFBytecodeNotSupported` on EOF bytecode.
+
+Both scans also have address-taking entry points that read the account's code,
+revert with `CodelessAccount` when there is none, and delegate to the bytes
+functions otherwise. An account with no code can gain any code later — an
+unoccupied `CREATE2` target, a self-destructed account between incarnations, or
+an EOA that can gain code by EIP-7702 delegation — so a zero bitmap for it would
+vouch for nothing, and only the address boundary has the information to refuse.
+The bytes entry points answer only about the bytes given: empty bytecode scans
+to a zero bitmap.
 
 ### Bytecode hashing and Solidity CBOR metadata
 

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -336,6 +336,17 @@ library LibExtrospectBytecode {
         }
     }
 
+    /// Reads `account`'s code and scans it for reachable opcodes, delegating
+    /// to `scanEVMOpcodesReachableInBytecode(bytes)`.
+    /// @param account The account whose code to scan.
+    /// @return A `uint256` where each bit represents the presence of a
+    /// reachable opcode in the account's code.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function scanEVMOpcodesReachableInBytecode(address account) internal view returns (uint256) {
+        bytes memory bytecode = account.code;
+        return scanEVMOpcodesReachableInBytecode(bytecode);
+    }
+
     /// Scans all opcodes present in bytecode, respecting PUSH* inline data.
     /// A trailing PUSH* whose inline data runs past the end of the bytecode
     /// ends the scan. The PUSH* opcode itself is recorded, and every byte after
@@ -374,5 +385,16 @@ library LibExtrospectBytecode {
                 if lt(push, 0x20) { cursor := add(cursor, add(push, 1)) }
             }
         }
+    }
+
+    /// Reads `account`'s code and scans it for present opcodes, delegating to
+    /// `scanEVMOpcodesPresentInBytecode(bytes)`.
+    /// @param account The account whose code to scan.
+    /// @return A `uint256` where each bit represents the presence of an
+    /// opcode in the account's code.
+    //forge-lint: disable-next-line(mixed-case-function)
+    function scanEVMOpcodesPresentInBytecode(address account) internal view returns (uint256) {
+        bytes memory bytecode = account.code;
+        return scanEVMOpcodesPresentInBytecode(bytecode);
     }
 }

--- a/src/lib/LibExtrospectBytecode.sol
+++ b/src/lib/LibExtrospectBytecode.sol
@@ -286,7 +286,8 @@ library LibExtrospectBytecode {
     /// NOTE: Empty bytecode scans to a zero bitmap: there are no bytes, so no
     /// opcode is reachable. The empty code of a codeless account scans the
     /// same way, and zero says nothing about what opcodes that account may
-    /// later gain.
+    /// later gain. Use `scanEVMOpcodesReachableInBytecode(address)` to bind
+    /// the scan to an account and reject a codeless one.
     /// @param bytecode The bytecode to scan.
     /// @return bytesReachable A `uint256` where each bit represents the presence
     /// of a reachable opcode in the source bytecode.
@@ -337,13 +338,22 @@ library LibExtrospectBytecode {
     }
 
     /// Reads `account`'s code and scans it for reachable opcodes, delegating
-    /// to `scanEVMOpcodesReachableInBytecode(bytes)`.
+    /// to `scanEVMOpcodesReachableInBytecode(bytes)`. Reverts with
+    /// `CodelessAccount` carrying the address when the account has no code:
+    /// an account with no code can gain any code later — an unoccupied
+    /// `CREATE2` target, a self-destructed account between incarnations, or
+    /// an EOA that can gain code by EIP-7702 delegation — so a zero bitmap
+    /// for it would vouch for nothing. Reverts with `EOFBytecodeNotSupported`
+    /// if the account's code is EOF, as the bytes scan does.
     /// @param account The account whose code to scan.
     /// @return A `uint256` where each bit represents the presence of a
     /// reachable opcode in the account's code.
     //forge-lint: disable-next-line(mixed-case-function)
     function scanEVMOpcodesReachableInBytecode(address account) internal view returns (uint256) {
         bytes memory bytecode = account.code;
+        if (bytecode.length == 0) {
+            revert CodelessAccount(account);
+        }
         return scanEVMOpcodesReachableInBytecode(bytecode);
     }
 
@@ -359,7 +369,8 @@ library LibExtrospectBytecode {
     /// NOTE: Empty bytecode scans to a zero bitmap: there are no bytes, so no
     /// opcode is present. The empty code of a codeless account scans the same
     /// way, and zero says nothing about what opcodes that account may later
-    /// gain.
+    /// gain. Use `scanEVMOpcodesPresentInBytecode(address)` to bind the scan
+    /// to an account and reject a codeless one.
     /// @param bytecode The bytecode to scan.
     /// @return bytesPresent A `uint256` where each bit represents the presence
     /// of an opcode in the source bytecode.
@@ -388,13 +399,22 @@ library LibExtrospectBytecode {
     }
 
     /// Reads `account`'s code and scans it for present opcodes, delegating to
-    /// `scanEVMOpcodesPresentInBytecode(bytes)`.
+    /// `scanEVMOpcodesPresentInBytecode(bytes)`. Reverts with
+    /// `CodelessAccount` carrying the address when the account has no code:
+    /// an account with no code can gain any code later — an unoccupied
+    /// `CREATE2` target, a self-destructed account between incarnations, or
+    /// an EOA that can gain code by EIP-7702 delegation — so a zero bitmap
+    /// for it would vouch for nothing. Reverts with `EOFBytecodeNotSupported`
+    /// if the account's code is EOF, as the bytes scan does.
     /// @param account The account whose code to scan.
     /// @return A `uint256` where each bit represents the presence of an
     /// opcode in the account's code.
     //forge-lint: disable-next-line(mixed-case-function)
     function scanEVMOpcodesPresentInBytecode(address account) internal view returns (uint256) {
         bytes memory bytecode = account.code;
+        if (bytecode.length == 0) {
+            revert CodelessAccount(account);
+        }
         return scanEVMOpcodesPresentInBytecode(bytecode);
     }
 }

--- a/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode.t.sol
@@ -141,6 +141,7 @@ import {HasLog4} from "test/concrete/HasLog4.sol";
 import {HasStop} from "test/concrete/HasStop.sol";
 import {HasRevert} from "test/concrete/HasRevert.sol";
 import {HasInvalid} from "test/concrete/HasInvalid.sol";
+import {LibExtrospectTestEtch} from "test/lib/LibExtrospectTestEtch.sol";
 
 contract LibExtrospectBytecodeScanEVMOpcodesPresentInBytecodeTest is Test {
     using LibBytes for bytes;
@@ -790,5 +791,55 @@ contract LibExtrospectBytecodeScanEVMOpcodesPresentInBytecodeTest is Test {
         bytes memory eofBytecode = hex"EF00010203";
         vm.expectRevert(LibExtrospectBytecode.EOFBytecodeNotSupported.selector);
         this.scanEVMOpcodesPresentInBytecodeExternal(eofBytecode);
+    }
+
+    /// External wrapper for address entry point revert tests.
+    function scanEVMOpcodesPresentInBytecodeAddressExternal(address account) external view returns (uint256) {
+        return LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(account);
+    }
+
+    /// Address entry point: a codeless account reverts with `CodelessAccount`
+    /// carrying the address. The bytes entry point returns zero for the same
+    /// account's (empty) code, pinned by
+    /// `testScanEVMOpcodesPresentCodelessAccount`; only the address boundary
+    /// can refuse to vouch for a codeless account.
+    function testScanEVMOpcodesPresentAddressRevertsOnCodelessAccount() public {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.CodelessAccount.selector, codeless));
+        this.scanEVMOpcodesPresentInBytecodeAddressExternal(codeless);
+    }
+
+    /// Address entry point: contract with SELFDESTRUCT scans with the
+    /// SELFDESTRUCT bit set, same as the bytes entry point over its code.
+    function testScanEVMOpcodesPresentAddressSelfdestruct() public {
+        HasSelfdestruct c = new HasSelfdestruct();
+        uint256 scan = LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(address(c));
+        //forge-lint: disable-next-line(incorrect-shift)
+        assertTrue(scan & (1 << uint256(EVM_OP_SELFDESTRUCT)) != 0);
+        assertEq(scan, LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(address(c).code));
+    }
+
+    /// Address entry point: EOF code etched onto an account reverts with
+    /// `EOFBytecodeNotSupported` via delegation to the bytes entry point.
+    function testScanEVMOpcodesPresentAddressRevertsOnEOF() public {
+        address target = address(0xBEEF);
+        vm.etch(target, hex"EF00010203");
+        vm.expectRevert(LibExtrospectBytecode.EOFBytecodeNotSupported.selector);
+        this.scanEVMOpcodesPresentInBytecodeAddressExternal(target);
+    }
+
+    /// Fuzz: for an account with nonempty non-EOF code, the address entry
+    /// point returns exactly what the bytes entry point returns for that code.
+    function testScanEVMOpcodesPresentAddressEquivalenceFuzz(bytes memory code) public {
+        vm.assume(code.length > 0);
+        vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
+        address target = address(0xBEEF);
+        LibExtrospectTestEtch.assumeEtch(vm, target, code);
+
+        assertEq(
+            LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(target),
+            LibExtrospectBytecode.scanEVMOpcodesPresentInBytecode(code)
+        );
     }
 }

--- a/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
+++ b/test/src/lib/LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode.t.sol
@@ -148,6 +148,7 @@ import {HasLog4} from "test/concrete/HasLog4.sol";
 import {HasStop} from "test/concrete/HasStop.sol";
 import {HasRevert} from "test/concrete/HasRevert.sol";
 import {HasInvalid} from "test/concrete/HasInvalid.sol";
+import {LibExtrospectTestEtch} from "test/lib/LibExtrospectTestEtch.sol";
 
 contract LibExtrospectScanEVMOpcodesReachableInBytecodeTest is Test {
     using LibBytes for bytes;
@@ -936,5 +937,56 @@ contract LibExtrospectScanEVMOpcodesReachableInBytecodeTest is Test {
         bytes memory eofBytecode = hex"EF00010203";
         vm.expectRevert(LibExtrospectBytecode.EOFBytecodeNotSupported.selector);
         this.scanEVMOpcodesReachableInBytecodeExternal(eofBytecode);
+    }
+
+    /// External wrapper for address entry point revert tests.
+    function scanEVMOpcodesReachableInBytecodeAddressExternal(address account) external view returns (uint256) {
+        return LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(account);
+    }
+
+    /// Address entry point: a codeless account reverts with `CodelessAccount`
+    /// carrying the address. The bytes entry point returns zero for the same
+    /// account's (empty) code, pinned by
+    /// `testScanEVMOpcodesReachableCodelessAccount`; only the address boundary
+    /// can refuse to vouch for a codeless account.
+    function testScanEVMOpcodesReachableAddressRevertsOnCodelessAccount() public {
+        address codeless = address(0xC2);
+        assertEq(codeless.code.length, 0);
+        vm.expectRevert(abi.encodeWithSelector(LibExtrospectBytecode.CodelessAccount.selector, codeless));
+        this.scanEVMOpcodesReachableInBytecodeAddressExternal(codeless);
+    }
+
+    /// Address entry point: contract with SELFDESTRUCT scans with the
+    /// SELFDESTRUCT bit reachable, same as the bytes entry point over its
+    /// code.
+    function testScanEVMOpcodesReachableAddressSelfdestruct() public {
+        HasSelfdestruct c = new HasSelfdestruct();
+        uint256 scan = LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(address(c));
+        //forge-lint: disable-next-line(incorrect-shift)
+        assertTrue(scan & (1 << uint256(EVM_OP_SELFDESTRUCT)) != 0);
+        assertEq(scan, LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(address(c).code));
+    }
+
+    /// Address entry point: EOF code etched onto an account reverts with
+    /// `EOFBytecodeNotSupported` via delegation to the bytes entry point.
+    function testScanEVMOpcodesReachableAddressRevertsOnEOF() public {
+        address target = address(0xBEEF);
+        vm.etch(target, hex"EF00010203");
+        vm.expectRevert(LibExtrospectBytecode.EOFBytecodeNotSupported.selector);
+        this.scanEVMOpcodesReachableInBytecodeAddressExternal(target);
+    }
+
+    /// Fuzz: for an account with nonempty non-EOF code, the address entry
+    /// point returns exactly what the bytes entry point returns for that code.
+    function testScanEVMOpcodesReachableAddressEquivalenceFuzz(bytes memory code) public {
+        vm.assume(code.length > 0);
+        vm.assume(!LibExtrospectBytecode.isEOFBytecode(code));
+        address target = address(0xBEEF);
+        LibExtrospectTestEtch.assumeEtch(vm, target, code);
+
+        assertEq(
+            LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(target),
+            LibExtrospectBytecode.scanEVMOpcodesReachableInBytecode(code)
+        );
     }
 }


### PR DESCRIPTION
Closes #83

Implements the ruling on #83 (2026-08-19, https://github.com/rainlanguage/rain.extrospection/issues/83#issuecomment-5342726009) exactly: the remaining opcode-scan half takes the same boundary rule as the metamorphic pair from PR #136. Address-taking `scanEVMOpcodesPresentInBytecode(address)` and `scanEVMOpcodesReachableInBytecode(address)` entry points revert with `CodelessAccount(address)` (the E+D class from #55) on a codeless account, before delegating to the existing bytes functions. Library-only: `IExtrospectV1` stays untouched, same as PR #136 — the interface surface for a new deploy is ruled separately (#139).

## What changed

- **`LibExtrospectBytecode`** gains the address-taking entry points `scanEVMOpcodesPresentInBytecode(address)` and `scanEVMOpcodesReachableInBytecode(address)`: both read the account's code, revert `CodelessAccount(account)` when there is none, and delegate to the bytes functions otherwise. An account with no code can gain any code later — an unoccupied `CREATE2` target, a self-destructed account between incarnations, or an EOA that can gain code by EIP-7702 delegation — so a zero bitmap for it would vouch for nothing, and only the address boundary has the information to refuse. Types-only returns with explicit `return`, per org convention.
- **Bytes-taking scans stay total over bytes.** `scanEVMOpcodesPresentInBytecode(bytes)` / `scanEVMOpcodesReachableInBytecode(bytes)` keep their behaviour, including the zero bitmap over empty bytes pinned since PR #136; their NatSpec now cross-references the address entry points as the way to bind a scan to an account.
- **README** Opcode scanning section documents the address entry points, paralleling the metamorphic section.
- **`IExtrospectV1`** untouched — no function or error added to or removed from the interface; `git diff main` touches no file under `src/interface/`.

Out of scope, untouched: #139 (interface-level surface for a new deploy), #54/#68/#82 (proxy and delegation resolution — the address entry points bind a verdict to the account's current code, nothing more).

## QA

- Discriminating tests:
  - `testScanEVMOpcodesPresentAddressRevertsOnCodelessAccount`, `testScanEVMOpcodesReachableAddressRevertsOnCodelessAccount` — codeless account reverts `CodelessAccount(0xC2)` from both address entry points, expected revert data built with `abi.encodeWithSelector(CodelessAccount.selector, codeless)` so the error AND its address payload are pinned; the bytes entry points still scan the same account's empty code to zero (`testScanEVMOpcodesPresentCodelessAccount`, `testScanEVMOpcodesReachableCodelessAccount`, unchanged from PR #136). Each fails on base: committed first (52852b1) against a guard-less scaffold and observed failing behaviourally ("next call did not revert as expected"; 396 passed, 5 failed = these 2 + the 3 environmental fork tests), then the guard commit (4d8b502) turned them green.
  - Address entry point delegation: `test*AddressSelfdestruct` (SELFDESTRUCT bit set and exact agreement with the bytes scan over a deployed contract's code), `test*AddressRevertsOnEOF` (`EOFBytecodeNotSupported` through the delegate on etched EOF code), `test*AddressEquivalenceFuzz` (address vs bytes agreement over nonempty non-EOF etched code, via `LibExtrospectTestEtch.assumeEtch`). These pass against the scaffold by construction; the mutation table below is what discriminates them.
- Mutations applied (each applied to the working tree, `nix develop -c forge test --no-match-path "*fork*"` run in full, then reverted; baseline for that command is 398 passed, 0 failed):
  | # | Mutant (applied to `src`, then reverted) | Outcome |
  |---|---|---|
  | M1 | `scanEVMOpcodesPresentInBytecode(address)`: codeless guard deleted | KILLED: `testScanEVMOpcodesPresentAddressRevertsOnCodelessAccount` ("next call did not revert as expected"); 397 passed, 1 failed |
  | M2 | `scanEVMOpcodesReachableInBytecode(address)`: codeless guard deleted | KILLED: `testScanEVMOpcodesReachableAddressRevertsOnCodelessAccount` (same shape); 397 passed, 1 failed |
  | M3 | Present guard reverts `CodelessAccount(address(0))` instead of the account | KILLED: revert-data mismatch `CodelessAccount(0x0000...0000) != CodelessAccount(0x0...00c2)` — the error's address payload is pinned; 397 passed, 1 failed |
  | M4 | Reachable guard reverts `CodelessAccount(address(0))` instead of the account | KILLED: same shape on the Reachable test; 397 passed, 1 failed |
  | M5 | Present address entry point delegates to the Reachable bytes scan | KILLED: `testScanEVMOpcodesPresentAddressEquivalenceFuzz` (counterexample where reachable != present); 397 passed, 1 failed |
  | M6 | Reachable address entry point delegates to the Present bytes scan | KILLED: `testScanEVMOpcodesReachableAddressEquivalenceFuzz` (counterexample `args=[0x...079f]`); 397 passed, 1 failed |
  | M7 | Present guard boundary `bytecode.length == 0` -> `== 1` | KILLED: `testScanEVMOpcodesPresentAddressRevertsOnCodelessAccount` (length 0 no longer reverts) and `testScanEVMOpcodesPresentAddressEquivalenceFuzz` with a 1-byte counterexample (`args=[0x32]` reverting `CodelessAccount(0xbEEF)`); 396 passed, 2 failed |
  | M8 | Reachable guard boundary `bytecode.length == 0` -> `== 1` | KILLED: same pair on the Reachable side (`args=[0x49]`); 396 passed, 2 failed |

  All 8 mutants killed, 0 survivors.
- Oracle: the RULING comment on #83 (https://github.com/rainlanguage/rain.extrospection/issues/83#issuecomment-5342726009), read independently of the implementation: the opcode-scan pair takes the metamorphic pair's boundary rule — address-taking entry points REVERT on a codeless account with `CodelessAccount(address)` per the E+D class from #55, before delegating to the bytes functions; library-only, `IExtrospectV1` untouched, interface ruled separately. Expected revert data in tests is constructed from the ruling's required shape via `abi.encodeWithSelector`, not observed from the code under test.
- Category check: the ruling asks for (1) `scanEVMOpcodesPresentInBytecode(address)` and `scanEVMOpcodesReachableInBytecode(address)` reverting `CodelessAccount(address)` on a codeless account — covered, `src/lib/LibExtrospectBytecode.sol`, revert and payload pinned; (2) delegation to the existing bytes functions — covered, pinned by the Selfdestruct-agreement, EOF and equivalence-fuzz tests; (3) library-only with `IExtrospectV1` untouched, same as PR #136 — covered, no `src/interface/` file in the diff; (4) PR #136's pattern for guard, error and test shapes — followed, including the failing-tests-first commit. Full suite: 398 passed, 3 failed — only the fork tests needing `ARBITRUM_RPC_URL` (environmental, fail on main too, #85). Nothing outside the ruled scope was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
