### PR TITLE
Drop foundry.toml release metadata: version intent lives in next-v tags (rainix#335)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,11 +1,3 @@
-# Release metadata, not foundry config. `rainix-autopublish` reads `version` as
-# the next, unpublished Soldeer release and rewrites the line when it publishes.
-# `[external.*]` is the section foundry reserves for another tool's config and
-# ignores.
-[external.package]
-name = "rain-extrospection"
-version = "0.1.13"
-
 [profile.default]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Deletes the `[external.package]` release-metadata section from `foundry.toml`, together with the comment block attached directly above it, per the ruling in rainlanguage/rainix#335. Since rainlanguage/rainix#336 merged, `rainix-autopublish` derives the publish version from the Soldeer registry plus `next-v*` git tags and never reads this section; the publish gate also excludes the section (including its attached comment block) from the content hash, so this deletion is content-neutral and cannot mint a release.

## QA
- Discriminating tests: n/a - config-metadata deletion; nothing reads the section since rainix#336. Verified locally: `nix develop -c reuse lint`, `nix develop -c forge soldeer install`, and `nix develop -c forge build` green. Suite left to CI: 107 test files including an arbitrum fork test needing RPC - pushed first rather than waiting on the long local run.
- Mutations applied: n/a - no code changed
- Oracle: rainix#336 gate semantics (section excluded from content hash; version from registry + next-v tags)
- Category check: issue asks removal of release metadata from consumers; covered exactly for this repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete release metadata from the project configuration.
  * No user-facing functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->