### PR TITLE
Delete the "load-bearing" filler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ deploy pins (creation bytecode, deterministic Zoltu address, runtime codehash)
 and the deploy tooling live in the rain.extrospection.deploy repo.
 
 **Orphaned bitmaps:** `NON_STATIC_OPS` and `INTERPRETER_DISALLOWED_OPS` have no
-consumer in `src/`. Only `test/src/lib/EVMOpcodes.t.sol` reads them, so they
-look load-bearing and are not.
+consumer in `src/`. Only `test/src/lib/EVMOpcodes.t.sol` reads them, so a
+search for consumers finds a hit and deleting them would break only that test.
 
 **Test layout:** `test/src/` mirrors `src/` by subject path. Test files named
 `Subject.functionName.t.sol`. `test/lib/` and `test/concrete/` are test-only


### PR DESCRIPTION
Removes the banned `load-bearing` filler from this repo's committed source.

The phrase rates a finding instead of stating one, and the reader can do the rating.
Where the surrounding sentence already named the consequence, the phrase is simply
deleted; otherwise it is replaced by the consequence it was standing in for. No
substitute rating word ("crucial", "key", "critical", "the crux", "significant",
"notably") was introduced anywhere in the diff.

Closes nothing — no issue exists for this. Part of an org-wide sweep; one PR per
affected repo. GitHub code search finds only some of the forms, so the sweep was run
against fresh clones of all 151 org repos, matching `load[-_ ]?bearing` case-insensitively
plus a check for the phrase wrapped across two comment lines.

### Occurrences removed

| File | Count |
| --- | --- |
| `CLAUDE.md` | 1 |

## QA

- Discriminating tests: n/a — nothing in the diff changes behaviour, so there is no
  behaviour for a test to discriminate.
- Mutations applied: n/a — the diff is comments and prose only. `mutation-probe` mutates
  source lines and asks whether the suite kills them; this diff changes no source line,
  so every mutant it could generate is a mutant of code this PR did not touch.
- Oracle: the code each comment describes. Every rewrite states the consequence the
  phrase was gesturing at, read off the surrounding implementation rather than invented.
- Category check: the request is "remove every occurrence from committed source";
  this repo's occurrences are all removed and a re-grep over the branch finds none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the architecture documentation regarding opcode lists used by tests.
  * Documented that removing these lists would affect testing only, not production functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->